### PR TITLE
Fix t-digest round-tripping issue

### DIFF
--- a/crates/t-digest/src/lib.rs
+++ b/crates/t-digest/src/lib.rs
@@ -133,7 +133,7 @@ impl TDigest {
         } else {
             let sz = centroids.len();
             let digests: Vec<TDigest> = vec![
-                TDigest::new_with_size(100),
+                TDigest::new_with_size(max_size),
                 TDigest::new(centroids, sum, count, max, min, sz),
             ];
 
@@ -364,6 +364,7 @@ impl TDigest {
             return TDigest::default();
         }
 
+        // TODO should this be the smaller of the sizes?
         let max_size = digests.first().unwrap().max_size;
         let mut centroids: Vec<Centroid> = Vec::with_capacity(n_centroids);
         let mut starts: Vec<usize> = Vec::with_capacity(digests.len());


### PR DESCRIPTION
Even when `count=max_buckets` there can be cases where the number of full buckets is smaller than `max_buckets`. Update the t-digest serialization to handle this case.