### PR TITLE
Json in/out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,12 +396,12 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 [[package]]
 name = "flat_serialize"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=b94ec65#b94ec654ad977a680dd23d72c8f9f41b7c533c62"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=fcf4593#fcf4593fb0411804a8c535bd7f0fd1634a07a21a"
 
 [[package]]
 name = "flat_serialize_macro"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=b94ec65#b94ec654ad977a680dd23d72c8f9f41b7c533c62"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=fcf4593#fcf4593fb0411804a8c535bd7f0fd1634a07a21a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ panic = "unwind"
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+debug = true

--- a/crates/t-digest/src/lib.rs
+++ b/crates/t-digest/src/lib.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 /// Centroid implementation to the cluster mentioned in the paper.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct Centroid {
     mean: OrderedFloat<f64>,
     weight: OrderedFloat<f64>,

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -26,11 +26,11 @@ paste = "1.0"
 
 [dependencies.flat_serialize]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "b94ec65"
+rev = "fcf4593"
 
 [dependencies.flat_serialize_macro]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "b94ec65"
+rev = "fcf4593"
 
 [dev-dependencies]
 pgx-tests = "0.1.6"

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -20,6 +20,9 @@ struct PallocAllocator;
 /// MemoryContext we allocate in, there doesn't seem to be way to do so that is
 /// safe in the context of postgres exceptions and doesn't incur the cost of
 /// setjmp
+// NOTE some code, for instance the JSON deserialization code in
+//      serde_reference_adaptor assumes it's ok to leak memory as postgres will
+//      clean it up
 unsafe impl GlobalAlloc for PallocAllocator {
     //FIXME allow for switching the memory context allocated in
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -1,5 +1,82 @@
+
+use std::{convert::TryInto, ffi::CStr, os::raw::{c_char, c_int}};
 pub use self::types::{PgTypId, ShortTypeId};
 pub use self::collations::PgCollationId;
 
 mod types;
 mod collations;
+
+
+
+// FIXME upstream to pgx
+pub(crate) const PG_UTF8: i32 = 6;
+extern "C" {
+    pub fn pg_server_to_any(s: *const c_char, len: c_int, encoding: c_int) -> *const c_char;
+    pub fn pg_any_to_server(s: *const c_char, len: c_int, encoding: c_int) -> *const c_char;
+    pub fn GetDatabaseEncoding() -> c_int;
+}
+
+pub enum EncodedStr<'s> {
+    Utf8(&'s str),
+    Other(&'s CStr)
+}
+
+pub fn str_to_db_encoding(s: &str) -> EncodedStr {
+    if unsafe { GetDatabaseEncoding() == PG_UTF8 } {
+        return EncodedStr::Utf8(s)
+    }
+
+    let bytes = s.as_bytes();
+    let encoded = unsafe {
+        pg_any_to_server(bytes.as_ptr() as *const c_char, bytes.len().try_into().unwrap(), PG_UTF8)
+    };
+    if encoded as usize == bytes.as_ptr() as usize {
+        return EncodedStr::Utf8(s)
+    }
+
+    let cstr = unsafe { CStr::from_ptr(encoded) };
+    return EncodedStr::Other(cstr)
+}
+
+pub fn str_from_db_encoding(s: &CStr) -> &str {
+    if unsafe { GetDatabaseEncoding() == PG_UTF8 } {
+        return s.to_str().unwrap()
+    }
+
+    let str_len = s.to_bytes().len().try_into().unwrap();
+    let encoded = unsafe {
+        pg_server_to_any(s.as_ptr(), str_len, PG_UTF8)
+    };
+    if encoded as usize == s.as_ptr() as usize {
+        //TODO redundant check?
+        return s.to_str().unwrap()
+    }
+    return unsafe { CStr::from_ptr(encoded).to_str().unwrap() }
+}
+
+// NOTE this module assumes that the rust allocator is the postgres allocator,
+//      and thus leaks memory assuming that MemoryContext deletion will clean
+//      it up
+pub(crate) mod serde_reference_adaptor {
+    use serde::{Deserialize, Deserializer};
+
+    pub(crate) fn deserialize<'de, D, T>(deserializer: D) -> Result<&'static T, D::Error>
+    where D: Deserializer<'de>, T: Deserialize<'de> {
+        let boxed = T::deserialize(deserializer)?.into();
+        Ok(Box::leak(boxed))
+    }
+
+    pub(crate) fn deserialize_slice<'de, D, T>(deserializer: D) -> Result<&'static [T], D::Error>
+    where D: Deserializer<'de>, T: Deserialize<'de> {
+        let boxed = <Box<[T]>>::deserialize(deserializer)?.into();
+        Ok(Box::leak(boxed))
+    }
+
+    pub(crate) fn default_padding() -> &'static [u8; 3] {
+        &[0; 3]
+    }
+
+    pub(crate) fn default_header() -> &'static u32 {
+        &0
+    }
+}


### PR DESCRIPTION
This allows us to to have TEXTual input for our types as well as output, allowing us to work correctly with pg_dump/restore, for not much more work. I'm not _entirely_ satisfied with either the formatting or effort-required, but both can be fixed later.
