### PR TITLE
Clean default JSON serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,12 +396,12 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 [[package]]
 name = "flat_serialize"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=fcf4593#fcf4593fb0411804a8c535bd7f0fd1634a07a21a"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=9e2582d#9e2582df885b1180ee8e9031cbbbe2143bb8bb5c"
 
 [[package]]
 name = "flat_serialize_macro"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=fcf4593#fcf4593fb0411804a8c535bd7f0fd1634a07a21a"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=9e2582d#9e2582df885b1180ee8e9031cbbbe2143bb8bb5c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -26,11 +26,11 @@ paste = "1.0"
 
 [dependencies.flat_serialize]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "fcf4593"
+rev = "9e2582d"
 
 [dependencies.flat_serialize_macro]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "fcf4593"
+rev = "9e2582d"
 
 [dev-dependencies]
 pgx-tests = "0.1.6"

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -118,13 +118,9 @@ pg_type!{
         // Oids are stored in postgres arrays, so it should be safe to store them
         // in our types as long as we do send/recv and in/out correctly
         // see https://github.com/postgres/postgres/blob/b8d0cda53377515ac61357ec4a60e85ca873f486/src/include/utils/array.h#L90
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         element_type: ShortTypeId,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         collation: PgCollationId,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         b: u32,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize_slice")]
         registers: [u8; (1 as usize) << self.b],
     }
 }

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -144,19 +144,12 @@ CREATE TYPE TDigest;
 pg_type! {
     #[derive(Debug)]
     struct TDigest {
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         buckets: u32,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         count: u32,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         sum: f64,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         min: f64,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         max: f64,
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize_slice")]
         centroids: [Centroid; self.buckets],
-        #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
         max_buckets: u32,
     }
 }

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -18,10 +18,13 @@ macro_rules! pg_type {
             flat_serialize_macro::flat_serialize! {
                 $(#[$attrs])?
                 #[derive(serde::Serialize, serde::Deserialize)]
+                #[flat_serialize::field_attr(
+                    fixed = r##"#[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]"##,
+                    variable = r##"#[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize_slice")]"##,
+                )]
                 struct [<$name Data>] {
                     #[serde(skip, default="crate::serialization::serde_reference_adaptor::default_header")]
                     header: u32,
-                    #[serde(deserialize_with = "crate::serialization::serde_reference_adaptor::deserialize")]
                     version: u8,
                     #[serde(skip, default="crate::serialization::serde_reference_adaptor::default_padding")]
                     padding: [u8; 3],


### PR DESCRIPTION
This PR updates `flat_serialize` to a newer version that allow annotating fields with attributes based on whether they are fixed or variable width. This allows us to use this functionality to annotate all our types with their field's deserializer and removes that boilerplate.