### PR TITLE
Hyperloglog union and bug fixes

### DIFF
--- a/extension/src/serialization/collations.rs
+++ b/extension/src/serialization/collations.rs
@@ -20,6 +20,14 @@ impl PgCollationId {
     pub fn is_invalid(&self) -> bool {
         self.0 == pg_sys::InvalidOid
     }
+
+    pub fn to_option_oid(&self) -> Option<Oid> {
+        if self.is_invalid() {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
 }
 
 // FIXME upstream to pgx


### PR DESCRIPTION
This operation calculates the count of distinct values across the combined Hyperloglog.

Also fixes a bug in our varlen handling: varlen types have a short version where there's only 1 byte of header and everything is stored in-line. This breaks one of the assumptions our value-wrapper is doing, so perform a copy in the case where we detect our value is in that form to ensure that we have the full 4-byte header. I believe this is the correct trade off, as the additional copy in the rare case that the value is small enough to use this optimization _should_ be less expensive than the additional disk space would be.