### PR TITLE
Ensure that TimescaleDB is preloaded in our CI image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -8,31 +8,37 @@ RUN useradd -ms /bin/bash postgres
 USER postgres
 
 # custom pgx until upstream workspace support is added
-RUN cd ~ \
+RUN set -ex \
+    && cd ~ \
     && git clone https://github.com/JLockerman/pgx.git \
     && cd pgx \
-    && git checkout fixed-syn-version
-
-RUN cd ~/pgx/cargo-pgx \
+    && git checkout pg_extern-schema-and-name \
+    && cd ~/pgx/cargo-pgx \
     && cargo install --path . \
     && cd ~ \
     && rm -rf ~/pgx
 
 # only use pg12 for now timescaledb doesn't support 13
-RUN cargo pgx init --pg12 download
+RUN set -ex \
+    && cargo pgx init --pg12 download \
+    && cargo pgx start pg12 \
+    && cargo pgx stop pg12
 
 # install timescaledb
 # TODO make seperate image from ^
-RUN cd ~ \
+RUN set -ex \
+    && cd ~ \
     && git clone https://github.com/timescale/timescaledb.git \
     && cd timescaledb \
     && git checkout 2.0.0
 
-RUN cd ~/timescaledb \
-    && ./bootstrap -DPG_CONFIG=~/.pgx/12.4/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
+RUN set -ex \
+    && cd ~/timescaledb \
+    && ./bootstrap -DPG_CONFIG=~/.pgx/12.6/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
     && cd build \
     && make -j4 \
     && make -j4 install \
+    && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-12/postgresql.conf \
     && cd ~ \
     && rm -rf ~/timescaledb
 


### PR DESCRIPTION
This is needed for tests on TimescaleDB to work. Also update pgx version since we're pushing a new Docker image anyway.