### PR TITLE
Schema-qualify experimental functions and remove unneeded prefixes

### DIFF
--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 // This is used to index the buckets of the UddSketch.  In particular, because UddSketch stores values
 // based on a logarithmic scale, we need to track negative values separately from positive values, and
 // zero also needs special casing.
-#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Copy, Clone, Ord)]
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Copy, Clone, Ord, Debug)]
 #[repr(C, u64)]
 pub enum SketchHashKey {
     Negative(i64),
@@ -55,7 +55,7 @@ impl SketchHashKey {
 }
 
 // Entries in the SketchHashMap contain a count and the next valid index of the map.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[derive(Clone)]
 struct SketchHashEntry {
     count: u64,
@@ -63,7 +63,7 @@ struct SketchHashEntry {
 }
 
 // SketchHashMap is a special hash map of SketchHashKey->count that also keeps the equivalent of a linked list of the entries by increasing key value.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[derive(Clone)]
 struct SketchHashMap {
     map: HashMap<SketchHashKey, SketchHashEntry>,
@@ -166,7 +166,7 @@ impl SketchHashMap {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UDDSketch {
     buckets: SketchHashMap,
     alpha: f64,

--- a/extension/docs/hyperloglog.md
+++ b/extension/docs/hyperloglog.md
@@ -20,7 +20,7 @@ Timescale's t-digest is implemented as an aggregate function in PostgreSQL.  The
 ---
 ## **hyperloglog** [](hyperloglog)
 ```SQL
-hyperloglog(
+timescale_analytics_experimental.hyperloglog(
     size INTEGER,
     value AnyElement¹
 ) RETURNS TDigest
@@ -47,13 +47,13 @@ This will construct and return a Hyperloglog with at least the specified number 
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
 ```SQL
-SELECT hyperloglog(64, data) FROM samples;
+SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other tdigest functions.
 
 ```SQL
-CREATE VIEW digest AS SELECT hyperloglog(64, data) FROM samples;
+CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
 ```
 
 ---
@@ -61,7 +61,7 @@ CREATE VIEW digest AS SELECT hyperloglog(64, data) FROM samples;
 ## **hyperloglog_count** [](hyperloglog_count)
 
 ```SQL
-hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
+timescale_analytics_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
 ```
 
 Get the number of distinct values from a hyperloglog.
@@ -82,7 +82,8 @@ Get the number of distinct values from a hyperloglog.
 ### Sample Usages [](hyperloglog_count-examples)
 
 ```SQL
-SELECT hyperloglog_count(hyperloglog(64, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.hyperloglog_count(hyperloglog(64, data))
+FROM generate_series(1, 100) data;
  hyperloglog_count
 -------------------
                103

--- a/extension/docs/tdigest.md
+++ b/extension/docs/tdigest.md
@@ -43,14 +43,14 @@ CREATE VIEW
 
 timescale_analytics=> SELECT
         name,
-        timescale_analytics_experimental.tdigest_count(tdigest)
+        timescale_analytics_experimental.get_count(tdigest)
     FROM high_temp;
-                 name                  | tdigest_count
----------------------------------------+---------------
- PORTLAND INTERNATIONAL AIRPORT, OR US |          7671
- LITCHFIELD PARK, AZ US                |          5881
- NY CITY CENTRAL PARK, NY US           |          7671
- MIAMI INTERNATIONAL AIRPORT, FL US    |          7671
+                 name                  | get_count
+---------------------------------------+-----------
+ PORTLAND INTERNATIONAL AIRPORT, OR US |      7671
+ LITCHFIELD PARK, AZ US                |      5881
+ NY CITY CENTRAL PARK, NY US           |      7671
+ MIAMI INTERNATIONAL AIRPORT, FL US    |      7671
 (4 rows)
 ```
 
@@ -58,9 +58,9 @@ We can then check to see the 99.5 percentile high temperature for each location.
 ```SQL
 timescale_analytics=> SELECT
         name,
-        timescale_analytics_experimental.tdigest_quantile(tdigest, 0.995)
+        timescale_analytics_experimental.quantile(tdigest, 0.995)
     FROM high_temp;
-                 name                  |  tdigest_quantile
+                 name                  |           quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |   98.4390837104072
  LITCHFIELD PARK, AZ US                | 114.97809722222223
@@ -72,14 +72,14 @@ Or even check to see what quantile 90F would fall at in each city.
 ```SQL
 timescale_analytics=> SELECT
         name,
-        timescale_analytics_experimental.tdigest_quantile_at_value(tdigest, 90.0)
+        timescale_analytics_experimental.quantile_at_value(tdigest, 90.0)
     FROM high_temp;
-                 name                  | tdigest_quantile_at_value
----------------------------------------+---------------------------
- PORTLAND INTERNATIONAL AIRPORT, OR US |        0.9609990016734108
- LITCHFIELD PARK, AZ US                |        0.5531621580122781
- NY CITY CENTRAL PARK, NY US           |        0.9657150306348585
- MIAMI INTERNATIONAL AIRPORT, FL US    |        0.8093468908877591
+                 name                  |  quantile_at_value
+---------------------------------------+--------------------
+ PORTLAND INTERNATIONAL AIRPORT, OR US | 0.9609990016734108
+ LITCHFIELD PARK, AZ US                | 0.5531621580122781
+ NY CITY CENTRAL PARK, NY US           | 0.9657150306348585
+ MIAMI INTERNATIONAL AIRPORT, FL US    | 0.8093468908877591
 (4 rows)
 ```
 
@@ -139,7 +139,7 @@ CREATE VIEW digest AS
 ## **tdigest_min** [](tdigest_min)
 
 ```SQL
-timescale_analytics_experimental.tdigest_min(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.get_min(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the minimum value from a t-digest.
@@ -160,7 +160,7 @@ Get the minimum value from a t-digest.
 ### Sample Usages [](tdigest-min-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_min(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_min(tdigest(100, data))
 FROM generate_series(1, 100) data;
  tdigest_min
 -------------
@@ -171,7 +171,7 @@ FROM generate_series(1, 100) data;
 ## **tdigest_max** [](tdigest_max)
 
 ```SQL
-timescale_analytics_experimental.tdigest_max(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.get_max(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the maximum value from a t-digest.
@@ -191,18 +191,18 @@ Get the maximum value from a t-digest.
 ### Sample Usage [](tdigest_max-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_max(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_max(tdigest(100, data))
 FROM generate_series(1, 100) data;
- tdigest_max
--------------
-         100
+ get_max
+---------
+     100
 (1 row)
 ```
 ---
 ## **tdigest_count** [](tdigest_count)
 
 ```SQL
-timescale_analytics_experimental.tdigest_count(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.get_count(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the number of values contained in a t-digest.
@@ -222,11 +222,11 @@ Get the number of values contained in a t-digest.
 ### Sample Usage [](tdigest_count-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_count(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_count(tdigest(100, data))
 FROM generate_series(1, 100) data;
- tdigest_count
----------------
-           100
+ get_count
+-----------
+       100
 (1 row)
 ```
 
@@ -234,7 +234,7 @@ FROM generate_series(1, 100) data;
 ## **tdigest_mean** [](tdigest_mean)
 
 ```SQL
-timescale_analytics_experimental.tdigest_mean(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.mean(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the average of all the values contained in a t-digest.
@@ -254,11 +254,11 @@ Get the average of all the values contained in a t-digest.
 ### Sample Usage [](tdigest_mean-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_mean(tdigest(100, data))
+SELECT timescale_analytics_experimental.mean(tdigest(100, data))
 FROM generate_series(1, 100) data;
- tdigest_mean
---------------
-         50.5
+ mean
+------
+ 50.5
 (1 row)
 ```
 
@@ -266,7 +266,7 @@ FROM generate_series(1, 100) data;
 ## **tdigest_sum** [](tdigest_sum)
 
 ```SQL
-timescale_analytics_experimental.tdigest_sum(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.sum(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the sum of all the values in a t-digest
@@ -286,11 +286,11 @@ Get the sum of all the values in a t-digest
 ### Sample Usage [](tdigest_sum-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_sum(tdigest(100, data))
+SELECT timescale_analytics_experimental.sum(tdigest(100, data))
 FROM generate_series(1, 100) data;
- tdigest_sum
--------------
-        5050
+  sum
+------
+ 5050
 (1 row)
 ```
 
@@ -298,7 +298,7 @@ FROM generate_series(1, 100) data;
 ## **tdigest_quantile** [](tdigest_quantile)
 
 ```SQL
-timescale_analytics_experimental.tdigest_quantile(
+timescale_analytics_experimental.quantile(
     digest TDigest,
     quantile DOUBLE PRECISION
 ) RETURNS TDigest
@@ -322,11 +322,11 @@ Get the approximate value at a quantile from a t-digest
 ### Sample Usage [](tdigest_quantile-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_quantile(tdigest(100, data), 0.90)
+SELECT timescale_analytics_experimental.quantile(tdigest(100, data), 0.90)
 FROM generate_series(1, 100) data;
- tdigest_quantile
-------------------
-             90.5
+ quantile
+----------
+     90.5
 (1 row)
 ```
 
@@ -334,7 +334,7 @@ FROM generate_series(1, 100) data;
 ## **tdigest_quantile_at_value** [](tdigest_quantile_at_value)
 
 ```SQL
-timescale_analytics_experimental.tdigest_quantile_at_value(
+timescale_analytics_experimental.quantile_at_value(
     digest TDigest,
     value DOUBLE PRECISION
 ) RETURNS TDigest
@@ -358,10 +358,10 @@ Estimate what quantile a given value would be located at in a t-digest.
 ### Sample Usage [](tdigest_quantile_at_value-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.tdigest_quantile_at_value(tdigest(100, data), 90)
+SELECT timescale_analytics_experimental.quantile_at_value(tdigest(100, data), 90)
 FROM generate_series(1, 100) data;
- tdigest_quantile_at_value
----------------------------
-                     0.895
+ quantile_at_value
+-------------------
+             0.895
 (1 row)
 ```

--- a/extension/docs/tdigest.md
+++ b/extension/docs/tdigest.md
@@ -35,9 +35,16 @@ timescale_analytics=> \d weather;
 Now let's create some t-digests for our different stations and verify that they're receiving data.
 
 ```SQL
-timescale_analytics=> CREATE VIEW high_temp AS SELECT name, tdigest(100, tmax) FROM weather GROUP BY name;
+timescale_analytics=> CREATE VIEW high_temp AS
+    SELECT name, timescale_analytics_experimental.tdigest(100, tmax)
+    FROM weather
+    GROUP BY name;
 CREATE VIEW
-timescale_analytics=> SELECT name, tdigest_count(tdigest) FROM high_temp;
+
+timescale_analytics=> SELECT
+        name,
+        timescale_analytics_experimental.tdigest_count(tdigest)
+    FROM high_temp;
                  name                  | tdigest_count
 ---------------------------------------+---------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |          7671
@@ -49,7 +56,10 @@ timescale_analytics=> SELECT name, tdigest_count(tdigest) FROM high_temp;
 
 We can then check to see the 99.5 percentile high temperature for each location.
 ```SQL
-timescale_analytics=> SELECT name, tdigest_quantile(tdigest, 0.995) FROM high_temp;
+timescale_analytics=> SELECT
+        name,
+        timescale_analytics_experimental.tdigest_quantile(tdigest, 0.995)
+    FROM high_temp;
                  name                  |  tdigest_quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |   98.4390837104072
@@ -60,7 +70,10 @@ timescale_analytics=> SELECT name, tdigest_quantile(tdigest, 0.995) FROM high_te
 ```
 Or even check to see what quantile 90F would fall at in each city.
 ```SQL
-timescale_analytics=> SELECT name, tdigest_quantile_at_value(tdigest, 90.0) FROM high_temp;
+timescale_analytics=> SELECT
+        name,
+        timescale_analytics_experimental.tdigest_quantile_at_value(tdigest, 90.0)
+    FROM high_temp;
                  name                  | tdigest_quantile_at_value
 ---------------------------------------+---------------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |        0.9609990016734108
@@ -84,7 +97,7 @@ timescale_analytics=> SELECT name, tdigest_quantile_at_value(tdigest, 90.0) FROM
 ---
 ## **tdigest** [](tdigest)
 ```SQL
-tdigest(
+timescale_analytics_experimental.tdigest(
     buckets INTEGER,
     value DOUBLE PRECISION
 ) RETURNS TDigest
@@ -110,13 +123,15 @@ This will construct and return a TDigest with the specified number of buckets ov
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
 ```SQL
-SELECT tdigest(100, data) FROM samples;
+SELECT timescale_analytics_experimental.tdigest(100, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other tdigest functions.
 
 ```SQL
-CREATE VIEW digest AS SELECT tdigest(100, data) FROM samples;
+CREATE VIEW digest AS
+    SELECT timescale_analytics_experimental.tdigest(100, data)
+    FROM samples;
 ```
 
 ---
@@ -124,7 +139,7 @@ CREATE VIEW digest AS SELECT tdigest(100, data) FROM samples;
 ## **tdigest_min** [](tdigest_min)
 
 ```SQL
-tdigest_min(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.tdigest_min(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the minimum value from a t-digest.
@@ -145,7 +160,8 @@ Get the minimum value from a t-digest.
 ### Sample Usages [](tdigest-min-examples)
 
 ```SQL
-SELECT tdigest_min(tdigest(100, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_min(tdigest(100, data))
+FROM generate_series(1, 100) data;
  tdigest_min
 -------------
            1
@@ -155,7 +171,7 @@ SELECT tdigest_min(tdigest(100, data)) FROM generate_series(1, 100) data;
 ## **tdigest_max** [](tdigest_max)
 
 ```SQL
-tdigest_max(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.tdigest_max(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the maximum value from a t-digest.
@@ -175,7 +191,8 @@ Get the maximum value from a t-digest.
 ### Sample Usage [](tdigest_max-examples)
 
 ```SQL
-SELECT tdigest_max(tdigest(100, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_max(tdigest(100, data))
+FROM generate_series(1, 100) data;
  tdigest_max
 -------------
          100
@@ -185,7 +202,7 @@ SELECT tdigest_max(tdigest(100, data)) FROM generate_series(1, 100) data;
 ## **tdigest_count** [](tdigest_count)
 
 ```SQL
-tdigest_count(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.tdigest_count(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the number of values contained in a t-digest.
@@ -205,7 +222,8 @@ Get the number of values contained in a t-digest.
 ### Sample Usage [](tdigest_count-examples)
 
 ```SQL
-SELECT tdigest_count(tdigest(100, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_count(tdigest(100, data))
+FROM generate_series(1, 100) data;
  tdigest_count
 ---------------
            100
@@ -216,7 +234,7 @@ SELECT tdigest_count(tdigest(100, data)) FROM generate_series(1, 100) data;
 ## **tdigest_mean** [](tdigest_mean)
 
 ```SQL
-tdigest_mean(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.tdigest_mean(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the average of all the values contained in a t-digest.
@@ -236,7 +254,8 @@ Get the average of all the values contained in a t-digest.
 ### Sample Usage [](tdigest_mean-examples)
 
 ```SQL
-SELECT tdigest_mean(tdigest(100, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_mean(tdigest(100, data))
+FROM generate_series(1, 100) data;
  tdigest_mean
 --------------
          50.5
@@ -247,7 +266,7 @@ SELECT tdigest_mean(tdigest(100, data)) FROM generate_series(1, 100) data;
 ## **tdigest_sum** [](tdigest_sum)
 
 ```SQL
-tdigest_sum(digest TDigest) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.tdigest_sum(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
 Get the sum of all the values in a t-digest
@@ -267,7 +286,8 @@ Get the sum of all the values in a t-digest
 ### Sample Usage [](tdigest_sum-examples)
 
 ```SQL
-SELECT tdigest_sum(tdigest(100, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_sum(tdigest(100, data))
+FROM generate_series(1, 100) data;
  tdigest_sum
 -------------
         5050
@@ -278,7 +298,7 @@ SELECT tdigest_sum(tdigest(100, data)) FROM generate_series(1, 100) data;
 ## **tdigest_quantile** [](tdigest_quantile)
 
 ```SQL
-tdigest_quantile(
+timescale_analytics_experimental.tdigest_quantile(
     digest TDigest,
     quantile DOUBLE PRECISION
 ) RETURNS TDigest
@@ -302,7 +322,8 @@ Get the approximate value at a quantile from a t-digest
 ### Sample Usage [](tdigest_quantile-examples)
 
 ```SQL
-SELECT tdigest_quantile(tdigest(100, data), 0.90) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_quantile(tdigest(100, data), 0.90)
+FROM generate_series(1, 100) data;
  tdigest_quantile
 ------------------
              90.5
@@ -313,7 +334,7 @@ SELECT tdigest_quantile(tdigest(100, data), 0.90) FROM generate_series(1, 100) d
 ## **tdigest_quantile_at_value** [](tdigest_quantile_at_value)
 
 ```SQL
-tdigest_quantile_at_value(
+timescale_analytics_experimental.tdigest_quantile_at_value(
     digest TDigest,
     value DOUBLE PRECISION
 ) RETURNS TDigest
@@ -337,7 +358,8 @@ Estimate what quantile a given value would be located at in a t-digest.
 ### Sample Usage [](tdigest_quantile_at_value-examples)
 
 ```SQL
-SELECT tdigest_quantile_at_value(tdigest(100, data), 90) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.tdigest_quantile_at_value(tdigest(100, data), 90)
+FROM generate_series(1, 100) data;
  tdigest_quantile_at_value
 ---------------------------
                      0.895

--- a/extension/docs/uddsketch.md
+++ b/extension/docs/uddsketch.md
@@ -39,9 +39,16 @@ timescale_analytics=> \d weather;
 Now let's create some UddSketches for our different stations and verify that they're receiving data.
 
 ```SQL
-timescale_analytics=> CREATE VIEW daily_rain AS SELECT name, uddsketch(100, 0.005, prcp) FROM weather GROUP BY name;
+timescale_analytics=> CREATE VIEW daily_rain AS
+    SELECT name, timescale_analytics_experimental.uddsketch(100, 0.005, prcp)
+    FROM weather
+    GROUP BY name;
 CREATE VIEW
-timescale_analytics=> SELECT name, uddsketch_count(uddsketch), uddsketch_error(uddsketch) FROM daily_rain;
+timescale_analytics=> SELECT
+    name,
+    timescale_analytics_experimental.uddsketch_count(uddsketch),
+    timescale_analytics_experimental.uddsketch_error(uddsketch)
+FROM daily_rain;
                  name                  | uddsketch_count |   uddsketch_error
 ---------------------------------------+-----------------+---------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |            7671 |  0.0199975003624472
@@ -55,7 +62,10 @@ Notice that 100 buckets proved to be insufficient to maintain 0.5% relative erro
 
 We can then check some rainfall quantiles to see how our stations compare.
 ```SQL
-timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.6) FROM daily_rain;
+timescale_analytics=> SELECT
+    name,
+    timescale_analytics_experimental.uddsketch_quantile(uddsketch, 0.6)
+FROM daily_rain;
                  name                  |  uddsketch_quantile
 ---------------------------------------+----------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 0.009850446542334412
@@ -64,7 +74,10 @@ timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.6) FROM daily
  MIAMI INTERNATIONAL AIRPORT, FL US    |                    0
 (4 rows)
 
-timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.9) FROM daily_rain;
+timescale_analytics=> SELECT
+    name,
+    timescale_analytics_experimental.uddsketch_quantile(uddsketch, 0.9)
+FROM daily_rain;
                  name                  | uddsketch_quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 0.3072142710699281
@@ -73,7 +86,10 @@ timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.9) FROM daily
  MIAMI INTERNATIONAL AIRPORT, FL US    | 0.5483701300878486
 (4 rows)
 
-timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.995) FROM daily_rain;
+timescale_analytics=> SELECT
+    name,
+    timescale_analytics_experimental.uddsketch_quantile(uddsketch, 0.995)
+FROM daily_rain;
                  name                  | uddsketch_quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 1.1969797510556823
@@ -95,7 +111,7 @@ timescale_analytics=> SELECT name, uddsketch_quantile(uddsketch, 0.995) FROM dai
 ---
 ## **uddsketch** [](uddsketch)
 ```SQL
-uddsketch(
+timescale_analytics_experimental.uddsketch(
     size INTEGER,
     max_error DOUBLE PRECISION,
     value DOUBLE PRECISION
@@ -123,20 +139,22 @@ This will construct and return a new UddSketch with at most `size` buckets.  The
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a sketch over that column
 
 ```SQL
-SELECT uddsketch(100, 0.01, data) FROM samples;
+SELECT timescale_analytics_experimental.uddsketch(100, 0.01, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other uddsketch functions.
 
 ```SQL
-CREATE VIEW sketch AS SELECT uddsketch(100, 0.01, data) FROM samples;
+CREATE VIEW sketch AS
+    SELECT timescale_analytics_experimental.uddsketch(100, 0.01, data)
+    FROM samples;
 ```
 
 ---
 ## **uddsketch_count** [](uddsketch_count)
 
 ```SQL
-uddsketch_count(sketch UddSketch) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.uddsketch_count(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
 Get the number of values contained in a UddSketch.
@@ -156,7 +174,9 @@ Get the number of values contained in a UddSketch.
 ### Sample Usage [](uddsketch_count-examples)
 
 ```SQL
-SELECT uddsketch_count(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.uddsketch_count(
+    timescale_analytics_experimental.uddsketch(100, 0.01, data)
+) FROM generate_series(1, 100) data;
  uddsketch_count
 ---------------
            100
@@ -168,7 +188,7 @@ SELECT uddsketch_count(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) 
 ## **uddsketch_error** [](uddsketch_error)
 
 ```SQL
-uddsketch_error(sketch UddSketch) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.uddsketch_error(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
 This returns the maximum relative error that a quantile estimate will have (relative to the correct value).  This will initially be the same as the `max_error` used to construct the UddSketch, but if the sketch has needed to combine buckets this function will return the new maximum error.
@@ -189,7 +209,9 @@ This returns the maximum relative error that a quantile estimate will have (rela
 ### Sample Usages [](uddsketch_error-examples)
 
 ```SQL
-SELECT uddsketch_error(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.uddsketch_error(
+    timescale_analytics_experimental.uddsketch(100, 0.01, data)
+) FROM generate_series(1, 100) data;
  uddsketch_error
 -------------
             0.01
@@ -200,7 +222,7 @@ SELECT uddsketch_error(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) 
 ## **uddsketch_mean** [](uddsketch_mean)
 
 ```SQL
-uddsketch_mean(sketch UddSketch) RETURNS DOUBLE PRECISION
+timescale_analytics_experimental.uddsketch_mean(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
 Get the average of all the values contained in a UddSketch.
@@ -220,7 +242,9 @@ Get the average of all the values contained in a UddSketch.
 ### Sample Usage [](uddsketch_mean-examples)
 
 ```SQL
-SELECT uddsketch_mean(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.uddsketch_mean(
+    timescale_analytics_experimental.uddsketch(100, 0.01, data)
+) FROM generate_series(1, 100) data;
  uddsketch_mean
 --------------
          50.5
@@ -231,7 +255,7 @@ SELECT uddsketch_mean(uddsketch(100, 0.01, data)) FROM generate_series(1, 100) d
 ## **uddsketch_quantile** [](uddsketch_quantile)
 
 ```SQL
-uddsketch_quantile(
+timescale_analytics_experimental.uddsketch_quantile(
     sketch UddSketch,
     quantile DOUBLE PRECISION
 ) RETURNS UddSketch
@@ -255,7 +279,10 @@ Get the approximate value at a quantile from a UddSketch.
 ### Sample Usage [](uddsketch_quantile-examples)
 
 ```SQL
-SELECT uddsketch_quantile(uddsketch(100, 0.01, data), 0.90) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.uddsketch_quantile(
+    timescale_analytics_experimental.uddsketch(100, 0.01, data),
+    0.90
+) FROM generate_series(1, 100) data;
  uddsketch_quantile
 --------------------
   89.13032933635797
@@ -266,7 +293,7 @@ SELECT uddsketch_quantile(uddsketch(100, 0.01, data), 0.90) FROM generate_series
 ## **uddsketch_quantile_at_value** [](uddsketch_quantile_at_value)
 
 ```SQL
-uddsketch_quantile_at_value(
+timescale_analytics_experimental.uddsketch_quantile_at_value(
     sketch UddSketch,
     value DOUBLE PRECISION
 ) RETURNS UddSketch
@@ -290,7 +317,10 @@ Estimate what quantile a given value would be located at in a UddSketch.
 ### Sample Usage [](uddsketch_quantile_at_value-examples)
 
 ```SQL
-SELECT uddsketch_quantile_at_value(uddsketch(100, 0.01, data), 90) FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.uddsketch_quantile_at_value(
+    uddsketch(100, 0.01, data),
+    90
+) FROM generate_series(1, 100) data;
  uddsketch_quantile_at_value
 ---------------------------
                      0.89

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -6,6 +6,7 @@ mod palloc;
 mod aggregate_utils;
 mod type_builder;
 mod serialization;
+mod schema_test;
 
 pgx::pg_module_magic!();
 

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -1,0 +1,78 @@
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use std::collections::HashSet;
+
+    use pgx::*;
+
+    // Test that any new features are added to the the experimental schema
+    #[pg_test]
+    fn test_schema_qualification() {
+        Spi::execute(|client| {
+            let released_features: HashSet<_> = RELEASED_FEATURES.iter().cloned().collect();
+            let unexpected_features: Vec<_> = client
+                .select(
+                    "SELECT pg_catalog.pg_describe_object(classid, objid, 0) \
+                    FROM pg_catalog.pg_extension e, pg_catalog.pg_depend d \
+                    WHERE e.extname='timescale_analytics' \
+                    AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass \
+                    AND d.refobjid = e.oid \
+                    AND deptype = 'e'
+                    ORDER BY 1",
+                    None,
+                    None,
+                ).filter_map(|row| {
+                    let val: String = row.by_ordinal(1).unwrap().value().unwrap();
+
+                    if released_features.contains(&*val) {
+                        return None
+                    }
+
+                    if val.starts_with("schema")
+                        && val.strip_prefix("schema ") == Some("timescale_analytics_experimental") {
+                        return None
+                    }
+
+                    if val.starts_with("schema")
+                        && val.strip_prefix("schema ") == Some("tests") {
+                        return None
+                    }
+
+                    let type_prefix = "type timescale_analytics_experimental.";
+                    if val.starts_with(type_prefix)
+                        && val.strip_prefix(type_prefix).is_some() {
+                            return None
+                    }
+
+                    let function_prefix = "function timescale_analytics_experimental.";
+                    if val.starts_with(function_prefix)
+                        && val.strip_prefix(function_prefix).is_some() {
+                            return None
+                    }
+
+                    // ignore the pgx test schema
+                    let test_prefix = "function tests.";
+                    if val.starts_with(test_prefix)
+                        && val.strip_prefix(test_prefix).is_some() {
+                            return None
+                    }
+
+                    return Some(val)
+                }).collect();
+
+            if unexpected_features.is_empty() {
+                return
+            }
+
+            panic!("unexpectedly released features: {:#?}", unexpected_features)
+        });
+    }
+
+    // list of features that are released and can be in places other than the
+    // experimental schema
+    // TODO it may pay to auto-discover this list based on the previous version of
+    //      the extension, once we have a released extension
+    static RELEASED_FEATURES: &[&'static str] = &[
+
+    ];
+}

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -198,7 +198,7 @@ CREATE AGGREGATE timescale_analytics_experimental.uddsketch(
 //---- Available PG operations on the sketch
 
 // Approximate the value at the given quantile (0.0-1.0)
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(name="quantile", schema = "timescale_analytics_experimental")]
 pub fn uddsketch_quantile(
     sketch: timescale_analytics_experimental::UddSketch,
     quantile: f64,
@@ -207,7 +207,7 @@ pub fn uddsketch_quantile(
 }
 
 // Approximate the quantile at the given value
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(name="quantile_at_value", schema = "timescale_analytics_experimental")]
 pub fn uddsketch_quantile_at_value(
     sketch: timescale_analytics_experimental::UddSketch,
     value: f64,
@@ -216,7 +216,7 @@ pub fn uddsketch_quantile_at_value(
 }
 
 // Number of elements from which the sketch was built.
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(name="get_count", schema = "timescale_analytics_experimental")]
 pub fn uddsketch_count(
     sketch: timescale_analytics_experimental::UddSketch,
 ) -> f64 {
@@ -225,7 +225,7 @@ pub fn uddsketch_count(
 
 // Average of all the values entered in the sketch.
 // Note that this is not an approximation, though there may be loss of precision.
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(name="mean", schema = "timescale_analytics_experimental")]
 pub fn uddsketch_mean(
     sketch: timescale_analytics_experimental::UddSketch,
 ) -> f64 {
@@ -237,7 +237,7 @@ pub fn uddsketch_mean(
 }
 
 // The maximum error (relative to the true value) for any quantile estimate.
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(name="error", schema = "timescale_analytics_experimental")]
 pub fn uddsketch_error(
     sketch: timescale_analytics_experimental::UddSketch
 ) -> f64 {
@@ -281,8 +281,8 @@ mod tests {
 
             let (mean, count) = client
                 .select("SELECT \
-                    timescale_analytics_experimental.uddsketch_mean(uddsketch), \
-                    timescale_analytics_experimental.uddsketch_count(uddsketch) \
+                    timescale_analytics_experimental.mean(uddsketch), \
+                    timescale_analytics_experimental.get_count(uddsketch) \
                     FROM sketch", None, None)
                 .first()
                 .get_two::<f64, f64>();
@@ -292,7 +292,7 @@ mod tests {
 
             let error = client
                 .select("SELECT \
-                    timescale_analytics_experimental.uddsketch_error(uddsketch) \
+                    timescale_analytics_experimental.error(uddsketch) \
                     FROM sketch", None, None)
                 .first()
                 .get_one::<f64>();
@@ -306,8 +306,8 @@ mod tests {
                 let (est_val, est_quant) = client
                     .select(
                         &format!("SELECT \
-                                timescale_analytics_experimental.uddsketch_quantile(uddsketch, {}), \
-                                timescale_analytics_experimental.uddsketch_quantile_at_value(uddsketch, {}) \
+                                timescale_analytics_experimental.quantile(uddsketch, {}), \
+                                timescale_analytics_experimental.quantile_at_value(uddsketch, {}) \
                             FROM sketch", quantile, value), None, None)
                     .first()
                     .get_two::<f64, f64>();

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -20,12 +20,21 @@ use crate::{
     palloc::Internal, pg_type
 };
 
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+    extension_sql!(r#"
+        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
+    "#);
+}
+
 #[allow(non_camel_case_types)]
 type int = u32;
 
 // PG function for adding values to a sketch.
 // Null values are ignored.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_trans(
     state: Option<Internal<UddSketchInternal>>,
     size: int,
@@ -50,7 +59,7 @@ pub fn uddsketch_trans(
 }
 
 // PG function for merging sketches.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_combine(
     state1: Option<Internal<UddSketchInternal>>,
     state2: Option<Internal<UddSketchInternal>>,
@@ -75,14 +84,14 @@ pub fn uddsketch_combine(
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
 
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_serialize(
     state: Internal<UddSketchInternal>,
 ) -> bytea {
     crate::do_serialize!(state)
 }
 
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -91,7 +100,7 @@ pub fn uddsketch_deserialize(
 }
 
 extension_sql!(r#"
-CREATE TYPE UddSketch;
+CREATE TYPE timescale_analytics_experimental.UddSketch;
 "#);
 
 // PG object for the sketch.
@@ -117,11 +126,11 @@ impl<'input> UddSketch<'input> {
 }
 
 // PG function to generate a user-facing UddSketch object from a UddSketchInternal.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 fn uddsketch_final(
     state: Option<Internal<UddSketchInternal>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<UddSketch<'static>> {
+) -> Option<timescale_analytics_experimental::UddSketch<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let mut state = match state {
@@ -157,64 +166,68 @@ fn uddsketch_final(
 }
 
 extension_sql!(r#"
-CREATE OR REPLACE FUNCTION UddSketch_in(cstring) RETURNS UddSketch IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C AS 'MODULE_PATHNAME', 'uddsketch_in_wrapper';
-CREATE OR REPLACE FUNCTION UddSketch_out(UddSketch) RETURNS CString IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C AS 'MODULE_PATHNAME', 'uddsketch_out_wrapper';
+CREATE OR REPLACE FUNCTION timescale_analytics_experimental.UddSketch_in(cstring)
+RETURNS timescale_analytics_experimental.UddSketch
+IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
+AS 'MODULE_PATHNAME', 'uddsketch_in_wrapper';
 
-CREATE TYPE UddSketch (
+CREATE OR REPLACE FUNCTION timescale_analytics_experimental.UddSketch_out(
+    timescale_analytics_experimental.UddSketch
+) RETURNS CString IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
+AS 'MODULE_PATHNAME', 'uddsketch_out_wrapper';
+
+CREATE TYPE timescale_analytics_experimental.UddSketch (
     INTERNALLENGTH = variable,
-    INPUT = UddSketch_in,
-    OUTPUT = UddSketch_out,
+    INPUT = timescale_analytics_experimental.UddSketch_in,
+    OUTPUT = timescale_analytics_experimental.UddSketch_out,
     STORAGE = extended
 );
 
-CREATE AGGREGATE uddsketch(size int, max_error DOUBLE PRECISION, value DOUBLE PRECISION)
-(
-    sfunc=uddsketch_trans,
-    stype=internal,
-    finalfunc=uddsketch_final,
-    combinefunc=uddsketch_combine,
-    serialfunc=uddsketch_serialize,
-    deserialfunc=uddsketch_deserialize
+CREATE AGGREGATE timescale_analytics_experimental.uddsketch(
+    size int, max_error DOUBLE PRECISION, value DOUBLE PRECISION
+) (
+    sfunc = timescale_analytics_experimental.uddsketch_trans,
+    stype = internal,
+    finalfunc = timescale_analytics_experimental.uddsketch_final,
+    combinefunc = timescale_analytics_experimental.uddsketch_combine,
+    serialfunc = timescale_analytics_experimental.uddsketch_serialize,
+    deserialfunc = timescale_analytics_experimental.uddsketch_deserialize
 );
 "#);
 
 //---- Available PG operations on the sketch
 
 // Approximate the value at the given quantile (0.0-1.0)
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_quantile(
-    sketch: UddSketch,
+    sketch: timescale_analytics_experimental::UddSketch,
     quantile: f64,
-    _fcinfo: pg_sys::FunctionCallInfo,
 ) -> f64 {
     sketch.to_uddsketch().estimate_quantile(quantile)
 }
 
 // Approximate the quantile at the given value
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_quantile_at_value(
-    sketch: UddSketch,
+    sketch: timescale_analytics_experimental::UddSketch,
     value: f64,
-    _fcinfo: pg_sys::FunctionCallInfo,
 ) -> f64 {
     sketch.to_uddsketch().estimate_quantile_at_value(value)
 }
 
 // Number of elements from which the sketch was built.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_count(
-    sketch: UddSketch,
-    _fcinfo: pg_sys::FunctionCallInfo,
+    sketch: timescale_analytics_experimental::UddSketch,
 ) -> f64 {
     *sketch.count as f64
 }
 
 // Average of all the values entered in the sketch.
 // Note that this is not an approximation, though there may be loss of precision.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_mean(
-    sketch: UddSketch,
-    _fcinfo: pg_sys::FunctionCallInfo,
+    sketch: timescale_analytics_experimental::UddSketch,
 ) -> f64 {
     if *sketch.count > 0 {
         *sketch.sum / *sketch.count as f64
@@ -224,9 +237,9 @@ pub fn uddsketch_mean(
 }
 
 // The maximum error (relative to the true value) for any quantile estimate.
-#[pg_extern]
+#[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn uddsketch_error(
-    sketch: UddSketch
+    sketch: timescale_analytics_experimental::UddSketch
 ) -> f64 {
     *sketch.alpha
 }
@@ -257,7 +270,9 @@ mod tests {
                 .get_one::<i32>();
             assert_eq!(Some(10000), sanity);
 
-            client.select("CREATE VIEW sketch AS SELECT uddsketch(100, 0.05, data) FROM test", None, None);
+            client.select("CREATE VIEW sketch AS \
+                SELECT timescale_analytics_experimental.uddsketch(100, 0.05, data) \
+                FROM test", None, None);
             let sanity = client
                 .select("SELECT COUNT(*) FROM sketch", None, None)
                 .first()
@@ -265,7 +280,10 @@ mod tests {
             assert!(sanity.unwrap_or(0) > 0);
 
             let (mean, count) = client
-                .select("SELECT uddsketch_mean(uddsketch), uddsketch_count(uddsketch) FROM sketch", None, None)
+                .select("SELECT \
+                    timescale_analytics_experimental.uddsketch_mean(uddsketch), \
+                    timescale_analytics_experimental.uddsketch_count(uddsketch) \
+                    FROM sketch", None, None)
                 .first()
                 .get_two::<f64, f64>();
 
@@ -273,7 +291,9 @@ mod tests {
             apx_eql(count.unwrap(), 10000.0, 0.000001);
 
             let error = client
-                .select("SELECT uddsketch_error(uddsketch) FROM sketch", None, None)
+                .select("SELECT \
+                    timescale_analytics_experimental.uddsketch_error(uddsketch) \
+                    FROM sketch", None, None)
                 .first()
                 .get_one::<f64>();
 
@@ -284,7 +304,11 @@ mod tests {
                 let quantile = value / 100.0;
 
                 let (est_val, est_quant) = client
-                    .select(&format!("SELECT uddsketch_quantile(uddsketch, {}), uddsketch_quantile_at_value(uddsketch, {}) FROM sketch", quantile, value), None, None)
+                    .select(
+                        &format!("SELECT \
+                                timescale_analytics_experimental.uddsketch_quantile(uddsketch, {}), \
+                                timescale_analytics_experimental.uddsketch_quantile_at_value(uddsketch, {}) \
+                            FROM sketch", quantile, value), None, None)
                     .first()
                     .get_two::<f64, f64>();
 


### PR DESCRIPTION
Our release process dictates that all new features get added to an experimental schema, and only get added to the public schema once they are fully baked and ready for release. This commit adds a test that all new functionality is in said schema, and schema-qualifies all currently in-development features.

Also, now that can have separate SQL and rust names, remove all the unneeded prefixes to the SQL functions.

supersedes #80 