### PR TITLE
Fix bug in t-digest serialization

### DIFF
--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -35,9 +35,9 @@ mod timescale_analytics_experimental {
 
 // Intermediate state kept in postgres.  This is a tdigest object paired
 // with a vector of values that still need to be inserted.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TDigestTransState {
-    #[serde(skip_serializing)]
+    #[serde(skip)]
     buffer: Vec<f64>,
     digested: InternalTDigest,
 }

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -188,8 +188,9 @@ macro_rules! do_serialize {
             use $crate::type_builder::SerializationType;
 
             let state = &*$state;
-            let size = bincode::serialized_size(state)
-                .unwrap_or_else(|e| pgx::error!("serialization error {}", e)) + 2;
+            let serialized_size = bincode::serialized_size(state)
+                .unwrap_or_else(|e| pgx::error!("serialization error {}", e));
+            let size = serialized_size + 2; // size of serialized data + our version flags
             let mut bytes = Vec::with_capacity(size as usize + 4);
             let varsize = [0; 4];
             bytes.extend_from_slice(&varsize);


### PR DESCRIPTION
We were using the wrong attribute; the one we used specified that the
fields should be skipped during serialization, but would be found during
in the bytes during deserialization. What we want her is the attribute
that specifies the field should be skipped during serialization, and
initialized using `Default::default()` during deserialization.