### PR TITLE
Add trigger disabling deps on experimental features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pgx"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#2919153eeaf17242e1769b379e8749cdc6ded412"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#429eadab3b37633fddf9ce2fda9f31c9b2065c52"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#2919153eeaf17242e1769b379e8749cdc6ded412"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#429eadab3b37633fddf9ce2fda9f31c9b2065c52"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#2919153eeaf17242e1769b379e8749cdc6ded412"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#429eadab3b37633fddf9ce2fda9f31c9b2065c52"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "pgx-tests"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#2919153eeaf17242e1769b379e8749cdc6ded412"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#429eadab3b37633fddf9ce2fda9f31c9b2065c52"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "pgx-utils"
 version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#2919153eeaf17242e1769b379e8749cdc6ded412"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#429eadab3b37633fddf9ce2fda9f31c9b2065c52"
 dependencies = [
  "colored",
  "dirs",

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -1,3 +1,4 @@
 tdigest.generated.sql
 hyperloglog.generated.sql
 uddsketch.generated.sql
+triggers.generated.sql

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,3 +1,6 @@
+
+pub mod triggers;
+
 pub mod tdigest;
 pub mod hyperloglog;
 pub mod uddsketch;
@@ -8,7 +11,24 @@ mod type_builder;
 mod serialization;
 mod schema_test;
 
+use pgx::*;
+
 pgx::pg_module_magic!();
+
+static EXPERIMENTAL_ENABLED: GucSetting<bool> = GucSetting::new(false);
+
+#[pg_guard]
+pub extern "C" fn _PG_init() {
+    GucRegistry::define_bool_guc(
+        "timescale_analytics_acknowledge_auto_drop",
+        "enable creation of auto-dropping objects using experimental timescale_analytics_features",
+        "experimental features are very unstable, and objects \
+            depending on them will be automatically deleted on extension update",
+        &EXPERIMENTAL_ENABLED,
+        //TODO should this be superuser?
+        GucContext::Userset,
+    );
+}
 
 #[cfg(test)]
 pub mod pg_test {

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -5,6 +5,20 @@ mod tests {
 
     use pgx::*;
 
+    #[pg_extern(schema="timescale_analytics_experimental")]
+    fn expected_failure() -> i32 { 1 }
+
+    #[pg_test(error = "features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.")]
+    fn test_blocks_view() {
+        Spi::execute(|client| {
+            let _ = client.select(
+                "CREATE VIEW failed AS SELECT timescale_analytics_experimental.expected_failure();",
+               None,
+                None);
+        })
+    }
+
+
     // Test that any new features are added to the the experimental schema
     #[pg_test]
     fn test_schema_qualification() {
@@ -73,6 +87,10 @@ mod tests {
     // TODO it may pay to auto-discover this list based on the previous version of
     //      the extension, once we have a released extension
     static RELEASED_FEATURES: &[&'static str] = &[
-
+        "event trigger disallow_experimental_deps",
+        "event trigger disallow_experimental_dependencies_on_views",
+        "function disallow_experimental_dependencies()",
+        "function disallow_experimental_view_dependencies()",
+        "function timescale_analytics_probe()",
     ];
 }

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -343,11 +343,24 @@ mod tests {
                 .get_one::<i32>();
             assert_eq!(10000, sanity.unwrap());
 
+            client.select(
+                "SET timescale_analytics_acknowledge_auto_drop TO 'true'",
+                None,
+                None,
+            );
+
             client.select("CREATE VIEW digest AS \
                 SELECT timescale_analytics_experimental.tdigest(100, data) FROM test",
                 None,
                 None
             );
+
+            client.select(
+                "RESET timescale_analytics_acknowledge_auto_drop",
+                None,
+                None,
+            );
+
             let (min, max, count) = client
                 .select("SELECT \
                     timescale_analytics_experimental.get_min(tdigest), \

--- a/extension/src/triggers.rs
+++ b/extension/src/triggers.rs
@@ -1,0 +1,105 @@
+use pgx::*;
+
+/// nop function that forces the extension binary to be loaded, this ensures
+/// that if a user sees the error message the guc will in fact be active
+#[pg_extern]
+fn timescale_analytics_probe() {
+
+}
+
+extension_sql!(r#"
+CREATE OR REPLACE FUNCTION disallow_experimental_dependencies()
+  RETURNS event_trigger
+ LANGUAGE plpgsql
+  AS $$
+DECLARE
+  guc_set TEXT;
+  experimental_schema_id oid;
+BEGIN
+
+  guc_set := current_setting('timescale_analytics_acknowledge_auto_drop', true);
+  IF guc_set IS NOT NULL AND guc_set = 'on' THEN
+    RETURN;
+  END IF;
+
+  SELECT oid schema_oid
+  INTO experimental_schema_id
+  FROM pg_catalog.pg_namespace
+  WHERE nspname='timescale_analytics_experimental'
+  LIMIT 1;
+
+  IF EXISTS (
+    SELECT top_dep.objid, top_dep.deptype, top_dep.refobjid
+    FROM pg_catalog.pg_depend top_dep
+    WHERE top_dep.refobjid=experimental_schema_id
+    AND top_dep.objid IN (
+      SELECT depend.refobjid dep_id
+      FROM pg_catalog.pg_depend depend
+      INNER JOIN (
+        SELECT obj.objid id
+        FROM pg_event_trigger_ddl_commands() as obj
+        WHERE NOT obj.in_extension
+      ) created ON created.id = depend.objid))
+  THEN
+    PERFORM timescale_analytics_probe();
+    RAISE EXCEPTION 'features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.'
+      USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescale_analytics_acknowledge_auto_drop to ''true''.';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION disallow_experimental_view_dependencies()
+RETURNS event_trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  guc_set TEXT;
+  experimental_schema_id oid;
+BEGIN
+
+  guc_set := current_setting('timescale_analytics_acknowledge_auto_drop', true);
+  IF guc_set IS NOT NULL AND guc_set = 'on' THEN
+    RETURN;
+  END IF;
+
+  SELECT oid schema_oid
+  INTO experimental_schema_id
+  FROM pg_catalog.pg_namespace
+  WHERE nspname='timescale_analytics_experimental'
+  LIMIT 1;
+
+  -- views do not depend directly on objects, instead the rewrite rule depends
+  -- on both the view, and the dependencies, so check for that
+  IF EXISTS (
+    SELECT top_dep.objid, top_dep.deptype, top_dep.refobjid
+    FROM pg_catalog.pg_depend top_dep
+    WHERE top_dep.refobjid=experimental_schema_id
+    AND top_dep.objid IN (
+      SELECT depend2.refobjid dep_id
+      FROM pg_catalog.pg_depend depend
+      INNER JOIN (
+        SELECT obj.objid id
+        FROM pg_event_trigger_ddl_commands() as obj
+        WHERE NOT obj.in_extension
+      ) created ON created.id = depend.refobjid
+      INNER JOIN pg_catalog.pg_depend depend2 ON depend2.objid = depend.objid)
+    )
+  THEN
+    PERFORM timescale_analytics_probe();
+    RAISE EXCEPTION 'features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.'
+        USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescale_analytics_acknowledge_auto_drop to ''true''.';
+  END IF;
+END;
+$$;
+
+CREATE EVENT TRIGGER disallow_experimental_deps ON ddl_command_end
+  WHEN tag IN ('CREATE AGGREGATE', 'CREATE CAST',
+    'CREATE FUNCTION', 'CREATE INDEX', 'CREATE MATERIALIZED VIEW',
+    'CREATE OPERATOR', 'CREATE PROCEDURE', 'CREATE TABLE', 'CREATE TABLE AS',
+    'CREATE TRIGGER', 'CREATE TYPE', 'CREATE VIEW')
+  EXECUTE FUNCTION disallow_experimental_dependencies();
+
+CREATE EVENT TRIGGER disallow_experimental_dependencies_on_views ON ddl_command_end
+  WHEN tag IN ('CREATE MATERIALIZED VIEW', 'CREATE VIEW')
+  EXECUTE FUNCTION disallow_experimental_view_dependencies();
+"#);

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -270,9 +270,22 @@ mod tests {
                 .get_one::<i32>();
             assert_eq!(Some(10000), sanity);
 
+            client.select(
+                "SET timescale_analytics_acknowledge_auto_drop TO 'true'",
+                None,
+                None,
+            );
+
             client.select("CREATE VIEW sketch AS \
                 SELECT timescale_analytics_experimental.uddsketch(100, 0.05, data) \
                 FROM test", None, None);
+
+            client.select(
+                "RESET timescale_analytics_acknowledge_auto_drop",
+                None,
+                None,
+            );
+
             let sanity = client
                 .select("SELECT COUNT(*) FROM sketch", None, None)
                 .first()


### PR DESCRIPTION
"experimental" features are just that, and there usage can be fraught: we are neither capable, not desirous, of providing an upgrade path for someone using experimental features to a newer version of this extension, and we would prefer users to not become reliant on experimental features. As such, our upgrade scripts for the extension are intended to contain a
`DROP SCHEMA timescale_analytics_experimental` at the start of the script. To ensure users are adequately warned of this risk, this commit adds a ddl_end trigger that prevents users from creating dependencies on experimental features unless they set a guc indicating they know the
implications of what they're doing.