### PR TITLE
Add notes about experimental features

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,10 @@ Run
 docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescaledev/timescale-analytics:nightly
 ```
 
+The extension contains experimental features in the `timecale_analytics_experimental`, schema
+see [our docs section on experimental features](/extension/docs/README.md#tag-notes) for
+more details.
+
 ## ✏️ Get Involved ##
 
 The Timescale Analytics project is still in the initial planning stage as we

--- a/extension/docs/README.md
+++ b/extension/docs/README.md
@@ -2,11 +2,11 @@
 ---
 The Timescale Analytics project contains a number of utilities for working with time-series data.  This documentation is further broken down by utility or feature in the list [below](#analytics-features).
 
-## A note on tags
+## A note on tags [](tag-notes)
 Functionality within the Timescale Analytics repository is intended to be introduced in varying stages of completeness.  To clarify which releases a given feature or function can be found in, the following tags are used:
- - Experimental - Denotes functionality that is still under very active development and may have poor performance, not handle corner cases or errors, etc.  Experimental APIs can be expected to change, or even completely dropped.  Experimental features and functions can be found in the Analytics nightly build, but will not be included in releases.
- - Stable ***release id*** - Functionality in this state should be correct and performant.  Stable APIs will be found in our releases and should not be broken in future releases.  Note that this tag will also be accompanied with the version in which the feature was originally released, such as: Feature Foo<sup><mark>stable-1.2</mark></sup>.
- - Deprecated - It may be necessary to remove stable functionality at some point, for instance if it is being supplanted by newer functionality or if it has deprecated dependencies.  Functionality with this tag is expected to be removed in future releases and current users of it should move to alternatives.
+ - **Experimental** - Denotes functionality that is still under very active development and may have poor performance, not handle corner cases or errors, etc.  Experimental APIs will change across releases, and extension-update will drop database objects that depend on experimental features. Do not use them unless you're willing ot deal with the object you've created being dropped on update. This is particularly important for Forge users, as automatic extension updates WILL DELETE database objects. Experimental features and functions can be found exclusively in the `timescale_analytics_experimental` schema.
+ - **Stable** ***release id*** - Functionality in this state should be correct and performant.  Stable APIs will be found in our releases and should not be broken in future releases.  Note that this tag will also be accompanied with the version in which the feature was originally released, such as: Feature Foo<sup><mark>stable-1.2</mark></sup>.
+ - **Deprecated** - It may be necessary to remove stable functionality at some point, for instance if it is being supplanted by newer functionality or if it has deprecated dependencies.  Functionality with this tag is expected to be removed in future releases and current users of it should move to alternatives.
 
 Note that tags can be applied at either a feature or function scope.  The function tag takes precedence, but defaults to the feature scope if not present.  For example, if we have a feature `Foo` which is tagged `stable`, we would assume that an untagged function `FooCount` within that feature would be present in the current beta release.  However, if function `FooSum` were explicitly tagged `experimental` then we would only expect to find it in the nightly build.
 
@@ -14,9 +14,9 @@ Note that tags can be applied at either a feature or function scope.  The functi
 
 The following links lead to pages for the different features in the Timescale Analytics repository.
 
-- [Hyperloglog](tdigest) <sup><mark>experimental</mark></sup> – An approximate `COUNT DISTINCT` based on hashing that provides reaonable accuracy in constant space. ([Methods](hyperloglog#hyperloglog_api))
-- [T-Digest](tdigest) <sup><mark>experimental</mark></sup> – A quantile estimate sketch optimized to provide more accurate estimates near the tails (i.e. 0.001 or 0.995) than conventional approaches. ([Methods](tdigest#tdigest_api))
-- [UddSketch](uddsketch) <sup><mark>experimental</mark></sup> – A quantile estimate sketch which provides a guaranteed maximum relative error. ([Methods](uddsketch#uddsketch_api))
+- [Hyperloglog](tdigest) [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes) – An approximate `COUNT DISTINCT` based on hashing that provides reaonable accuracy in constant space. ([Methods](hyperloglog#hyperloglog_api))
+- [T-Digest](tdigest) [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes) – A quantile estimate sketch optimized to provide more accurate estimates near the tails (i.e. 0.001 or 0.995) than conventional approaches. ([Methods](tdigest#tdigest_api))
+- [UddSketch](uddsketch) [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes) – A quantile estimate sketch which provides a guaranteed maximum relative error. ([Methods](uddsketch#uddsketch_api))
 
 [tdigest]: /extension/docs/tdigest.md
 [hyperloglog]: /extension/docs/hyperloglog.md

--- a/extension/docs/hyperloglog.md
+++ b/extension/docs/hyperloglog.md
@@ -1,4 +1,4 @@
-# Hyperloglog <sup><mark>experimental</mark></sup>
+# Hyperloglog [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes)
 
 > [Description](#hyperloglog-description)<br>
 > [Details](#hyperloglog-details)<br>

--- a/extension/docs/tdigest.md
+++ b/extension/docs/tdigest.md
@@ -1,4 +1,4 @@
-# T-Digest <sup><mark>experimental</mark></sup>
+# T-Digest [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes)
 
 > [Description](#tdigest-description)<br>
 > [Details](#tdigest-details)<br>

--- a/extension/docs/uddsketch.md
+++ b/extension/docs/uddsketch.md
@@ -1,4 +1,4 @@
-# UddSketch <sup><mark>experimental</mark></sup>
+# UddSketch [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes)
 
 > [Description](#uddsketch-description)<br>
 > [Details](#uddsketch-details)<br>


### PR DESCRIPTION
Key points:
 1. They are experimental, and shouldn't be relied on to stay the same.
 2. Updating the extension will drop things that depend on experimental
    features.