### PR TITLE
Add SQL doctester

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
     - name: Run Postgres Tests
       run: cd extension && sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx test pg12"
+
+    - name: Run Doc Tests
+      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg12 && /usr/local/cargo/bin/cargo pgx start pg12 && cd extension && /usr/local/cargo/bin/cargo pgx run pg12" && sql-doctester -h localhost -s 'CREATE EXTENSION timescaledb; CREATE EXTENSION timescale_analytics' -p 28812 docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -595,6 +596,15 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1148,6 +1158,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1385,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1552,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sql-doctester"
+version = "0.1.0"
+dependencies = [
+ "bytecount",
+ "clap",
+ "colored",
+ "postgres",
+ "pulldown-cmark",
+ "rayon",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1695,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 
@@ -1902,6 +1958,17 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ members = [
     "crates/t-digest",
     "crates/hyperloglog",
     "crates/udd-sketch",
-    "crates/time-weighted-average",]
+    "crates/time-weighted-average",
+    "tools/sql-doctester",
+]
 
 [profile.dev]
 panic = "unwind"

--- a/crates/t-digest/Cargo.toml
+++ b/crates/t-digest/Cargo.toml
@@ -9,4 +9,5 @@ ordered-float = "1.0"
 serde = { package = "serde", version = "1.0", optional = true, default-features = false }
 
 [features]
+default = ["use_serde"]
 use_serde = ["serde", "serde/derive", "ordered-float/serde"]

--- a/crates/time-weighted-average/Cargo.toml
+++ b/crates/time-weighted-average/Cargo.toml
@@ -10,4 +10,5 @@ edition = "2018"
 serde = { package = "serde", version = "1.0", optional = true, default-features = false }
 
 [features]
+default = ["use_serde"]
 use_serde = ["serde", "serde/derive"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -34,4 +34,7 @@ RUN set -ex \
     && cd ~ \
     && rm -rf ~/timescaledb
 
+# install doctester
+RUN cargo install --git https://github.com/timescale/timescale-analytics.git --branch jl/doctester sql-doctester
+
 USER root

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg12"]
+default = []
 pg10 = ["pgx/pg10", "pgx-tests/pg10"]
 pg11 = ["pgx/pg11", "pgx-tests/pg11"]
 pg12 = ["pgx/pg12", "pgx-tests/pg12"]

--- a/extension/docs/hyperloglog.md
+++ b/extension/docs/hyperloglog.md
@@ -19,7 +19,7 @@ Timescale's t-digest is implemented as an aggregate function in PostgreSQL.  The
 
 ---
 ## **hyperloglog** [](hyperloglog)
-```SQL
+```SQL,ignore
 timescale_analytics_experimental.hyperloglog(
     size INTEGER,
     value AnyElement¹
@@ -46,13 +46,13 @@ This will construct and return a Hyperloglog with at least the specified number 
 ### Sample Usages [](hyperloglog-examples)
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
-```SQL
+```SQL ,ignore
 SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other tdigest functions.
 
-```SQL
+```SQL ,ignore
 CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
 ```
 
@@ -60,7 +60,7 @@ CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, da
 
 ## **hyperloglog_count** [](hyperloglog_count)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
 ```
 
@@ -82,10 +82,11 @@ Get the number of distinct values from a hyperloglog.
 ### Sample Usages [](hyperloglog_count-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.hyperloglog_count(hyperloglog(64, data))
-FROM generate_series(1, 100) data;
+SELECT timescale_analytics_experimental.hyperloglog_count(timescale_analytics_experimental.hyperloglog(64, data))
+FROM generate_series(1, 100) data
+```
+```output
  hyperloglog_count
 -------------------
                103
-(1 row)
 ```

--- a/extension/docs/tdigest.md
+++ b/extension/docs/tdigest.md
@@ -17,8 +17,10 @@ Timescale's t-digest is implemented as an aggregate function in PostgreSQL.  The
 
 For this example we're going to start with a table containing some NOAA weather data for a few weather stations across the US over the past 20 years.
 
-```SQL
-timescale_analytics=> \d weather;
+```SQL ,ignore
+\d weather;
+```
+```
                          Table "public.weather"
  Column  |            Type             | Collation | Nullable | Default
 ---------+-----------------------------+-----------+----------+---------
@@ -34,17 +36,18 @@ timescale_analytics=> \d weather;
 
 Now let's create some t-digests for our different stations and verify that they're receiving data.
 
-```SQL
-timescale_analytics=> CREATE VIEW high_temp AS
+```SQL ,ignore
+CREATE VIEW high_temp AS
     SELECT name, timescale_analytics_experimental.tdigest(100, tmax)
     FROM weather
     GROUP BY name;
-CREATE VIEW
 
-timescale_analytics=> SELECT
-        name,
-        timescale_analytics_experimental.get_count(tdigest)
-    FROM high_temp;
+SELECT
+    name,
+    timescale_analytics_experimental.get_count(tdigest)
+FROM high_temp;
+```
+```
                  name                  | get_count
 ---------------------------------------+-----------
  PORTLAND INTERNATIONAL AIRPORT, OR US |      7671
@@ -55,11 +58,13 @@ timescale_analytics=> SELECT
 ```
 
 We can then check to see the 99.5 percentile high temperature for each location.
-```SQL
-timescale_analytics=> SELECT
-        name,
-        timescale_analytics_experimental.quantile(tdigest, 0.995)
-    FROM high_temp;
+```SQL ,ignore
+SELECT
+    name,
+    timescale_analytics_experimental.quantile(tdigest, 0.995)
+FROM high_temp;
+```
+```
                  name                  |           quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |   98.4390837104072
@@ -69,11 +74,13 @@ timescale_analytics=> SELECT
 (4 rows)
 ```
 Or even check to see what quantile 90F would fall at in each city.
-```SQL
-timescale_analytics=> SELECT
-        name,
-        timescale_analytics_experimental.quantile_at_value(tdigest, 90.0)
-    FROM high_temp;
+```SQL ,ignore
+SELECT
+    name,
+    timescale_analytics_experimental.quantile_at_value(tdigest, 90.0)
+FROM high_temp;
+```
+```
                  name                  |  quantile_at_value
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 0.9609990016734108
@@ -96,7 +103,7 @@ timescale_analytics=> SELECT
 
 ---
 ## **tdigest** [](tdigest)
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.tdigest(
     buckets INTEGER,
     value DOUBLE PRECISION
@@ -122,13 +129,13 @@ This will construct and return a TDigest with the specified number of buckets ov
 ### Sample Usages [](tdigest-examples)
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
-```SQL
+```SQL ,ignore
 SELECT timescale_analytics_experimental.tdigest(100, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other tdigest functions.
 
-```SQL
+```SQL ,ignore
 CREATE VIEW digest AS
     SELECT timescale_analytics_experimental.tdigest(100, data)
     FROM samples;
@@ -138,7 +145,7 @@ CREATE VIEW digest AS
 
 ## **tdigest_min** [](tdigest_min)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.get_min(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
@@ -160,17 +167,18 @@ Get the minimum value from a t-digest.
 ### Sample Usages [](tdigest-min-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.get_min(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_min(timescale_analytics_experimental.tdigest(100, data))
 FROM generate_series(1, 100) data;
+```
+```output
  tdigest_min
 -------------
            1
-(1 row)
 ```
 ---
 ## **tdigest_max** [](tdigest_max)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.get_max(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
@@ -191,17 +199,18 @@ Get the maximum value from a t-digest.
 ### Sample Usage [](tdigest_max-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.get_max(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_max(timescale_analytics_experimental.tdigest(100, data))
 FROM generate_series(1, 100) data;
+```
+```output
  get_max
 ---------
      100
-(1 row)
 ```
 ---
 ## **tdigest_count** [](tdigest_count)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.get_count(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
@@ -222,18 +231,19 @@ Get the number of values contained in a t-digest.
 ### Sample Usage [](tdigest_count-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.get_count(tdigest(100, data))
+SELECT timescale_analytics_experimental.get_count(timescale_analytics_experimental.tdigest(100, data))
 FROM generate_series(1, 100) data;
+```
+```output
  get_count
 -----------
        100
-(1 row)
 ```
 
 ---
 ## **tdigest_mean** [](tdigest_mean)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.mean(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
@@ -254,18 +264,19 @@ Get the average of all the values contained in a t-digest.
 ### Sample Usage [](tdigest_mean-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.mean(tdigest(100, data))
+SELECT timescale_analytics_experimental.mean(timescale_analytics_experimental.tdigest(100, data))
 FROM generate_series(1, 100) data;
+```
+```output
  mean
 ------
  50.5
-(1 row)
 ```
 
 ---
 ## **tdigest_sum** [](tdigest_sum)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.sum(digest TDigest) RETURNS DOUBLE PRECISION
 ```
 
@@ -286,18 +297,19 @@ Get the sum of all the values in a t-digest
 ### Sample Usage [](tdigest_sum-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.sum(tdigest(100, data))
+SELECT timescale_analytics_experimental.sum(timescale_analytics_experimental.tdigest(100, data))
 FROM generate_series(1, 100) data;
+```
+```output
   sum
 ------
  5050
-(1 row)
 ```
 
 ---
 ## **tdigest_quantile** [](tdigest_quantile)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.quantile(
     digest TDigest,
     quantile DOUBLE PRECISION
@@ -322,18 +334,19 @@ Get the approximate value at a quantile from a t-digest
 ### Sample Usage [](tdigest_quantile-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.quantile(tdigest(100, data), 0.90)
+SELECT timescale_analytics_experimental.quantile(timescale_analytics_experimental.tdigest(100, data), 0.90)
 FROM generate_series(1, 100) data;
+```
+```output
  quantile
 ----------
      90.5
-(1 row)
 ```
 
 ---
 ## **tdigest_quantile_at_value** [](tdigest_quantile_at_value)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.quantile_at_value(
     digest TDigest,
     value DOUBLE PRECISION
@@ -358,10 +371,11 @@ Estimate what quantile a given value would be located at in a t-digest.
 ### Sample Usage [](tdigest_quantile_at_value-examples)
 
 ```SQL
-SELECT timescale_analytics_experimental.quantile_at_value(tdigest(100, data), 90)
+SELECT timescale_analytics_experimental.quantile_at_value(timescale_analytics_experimental.tdigest(100, data), 90)
 FROM generate_series(1, 100) data;
+```
+```output
  quantile_at_value
 -------------------
              0.895
-(1 row)
 ```

--- a/extension/docs/time_weighted_average.md
+++ b/extension/docs/time_weighted_average.md
@@ -9,16 +9,16 @@
 
 ## Description [](time-weighted-average-description)
 
-Time weighted averages are commonly used in cases where a time series is not evenly sampled, so a traditional average will give misleading results. Consider a voltage sensor that sends readings once every 5 minutes or whenever the value changes by more than 1 V from the previous reading. If the results are generally stable, but with some quick moving transients, a simple average over all of the points will tend to over-weight the transients instead of the stable readings. A time weighted average weights each value by the duration over which it occured based on the points around it and produces correct results for unevenly spaced series. 
+Time weighted averages are commonly used in cases where a time series is not evenly sampled, so a traditional average will give misleading results. Consider a voltage sensor that sends readings once every 5 minutes or whenever the value changes by more than 1 V from the previous reading. If the results are generally stable, but with some quick moving transients, a simple average over all of the points will tend to over-weight the transients instead of the stable readings. A time weighted average weights each value by the duration over which it occured based on the points around it and produces correct results for unevenly spaced series.
 
-Timescale Analytics' time weighted average is implemented as an aggregate which weights each value either using a last observation carried forward (LOCF) approach or a linear interpolation approach ([see interpolation methods](#time-weight-methods)). While the aggregate is not parallelizable, it is supported with [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates). 
+Timescale Analytics' time weighted average is implemented as an aggregate which weights each value either using a last observation carried forward (LOCF) approach or a linear interpolation approach ([see interpolation methods](#time-weight-methods)). While the aggregate is not parallelizable, it is supported with [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
-Additionally, [see the notes on parallelism and ordering](#time-weight-ordering) for a deeper dive into considerations for use with parallelism and some discussion of the internal data structures. 
+Additionally, [see the notes on parallelism and ordering](#time-weight-ordering) for a deeper dive into considerations for use with parallelism and some discussion of the internal data structures.
 
 ---
 ## Example Usage [](time-weighted-average-examples)
 For these examples we'll assume a table `foo` defined as follows:
-```SQL
+```SQL ,ignore
 CREATE TABLE foo (
     measure_id      BIGINT,
     ts              TIMESTAMPTZ ,
@@ -27,10 +27,10 @@ CREATE TABLE foo (
 );
 
 ```
-Where the measure_id defines a series of related points. A simple use would be to calculate the time weighted average over the whole set of points for each `measure_id`. We'll use the LOCF method for weighting: 
+Where the measure_id defines a series of related points. A simple use would be to calculate the time weighted average over the whole set of points for each `measure_id`. We'll use the LOCF method for weighting:
 
-```SQL
-SELECT measure_id, 
+```SQL ,ignore
+SELECT measure_id,
     timescale_analytics_experimental.average(
         timescale_analytics_experimental.time_weight('LOCF', ts, val)
     )
@@ -40,10 +40,10 @@ GROUP BY measure_id;
 (And of course a where clause can be used to limit the time period we are averaging, the measures we're using etc.).
 
 
-We can also use the [`time_bucket` function](https://docs.timescale.com/latest/api#time_bucket) to produce a series averages in 15 minute buckets: 
-```SQL
-SELECT measure_id, 
-    time_bucket('15 min'::interval, ts) as bucket, 
+We can also use the [`time_bucket` function](https://docs.timescale.com/latest/api#time_bucket) to produce a series averages in 15 minute buckets:
+```SQL ,ignore
+SELECT measure_id,
+    time_bucket('15 min'::interval, ts) as bucket,
     timescale_analytics_experimental.average(
         timescale_analytics_experimental.time_weight('LOCF', ts, val)
     )
@@ -51,37 +51,40 @@ FROM foo
 GROUP BY measure_id, time_bucket('15 min'::interval, ts);
 ```
 
-Of course this might be more useful if we make a continuous aggregate out of it. We'll first have to make it a hypertable partitioned on the ts column, with a relatively large chunk_time_interval because the data isn't too high rate: 
+Of course this might be more useful if we make a continuous aggregate out of it. We'll first have to make it a hypertable partitioned on the ts column, with a relatively large chunk_time_interval because the data isn't too high rate:
 
-```SQL
+```SQL ,ignore
 SELECT create_hypertable('foo', 'ts', chunk_time_interval=> '15 days'::interval, migrate_data => true);
 ```
 
 Now we can make our continuous aggregate:
 
-```SQL
-CREATE MATERIALIZED VIEW foo_15 
+```SQL ,ignore
+CREATE MATERIALIZED VIEW foo_15
 WITH (timescaledb.continuous)
-AS SELECT measure_id, 
-    time_bucket('15 min'::interval, ts) as bucket, 
+AS SELECT measure_id,
+    time_bucket('15 min'::interval, ts) as bucket,
     timescale_analytics_experimental.time_weight('LOCF', ts, val)
 FROM foo
 GROUP BY measure_id, time_bucket('15 min'::interval, ts);
 ```
 
-Note that here, we just use the `time_weight` function. It's often better to do that and simply run the `average` function when selecting from the view like so: 
-```SQL
-SELECT measure_id, 
-    bucket, 
+Note that here, we just use the `time_weight` function. It's often better to do that and simply run the `average` function when selecting from the view like so:
+```SQL ,ignore
+SELECT
+    measure_id,
+    bucket,
     timescale_analytics_experimental.average(time_weight)
 FROM foo_15
 ```
 
 It also allows us to re-aggregate from the continuous aggregate into a larger bucket size quite simply:
 
-```SQL
-SELECT measure_id, 
-    time_bucket('1 day'::interval, bucket), timescale_analytics_experimental.average(
+```SQL ,ignore
+SELECT
+    measure_id,
+    time_bucket('1 day'::interval, bucket),
+    timescale_analytics_experimental.average(
             timescale_analytics_experimental.time_weight(time_weight)
     )
 FROM foo_15
@@ -90,8 +93,9 @@ GROUP BY measure_id, time_bucket('1 day'::interval, bucket);
 
 We can also use this to speed up our initial calculation where we're only grouping by measure_id and producing a full average (assuming we have a fair number of points per 15 minute period):
 
-```SQL
-SELECT measure_id,
+```SQL ,ignore
+SELECT
+    measure_id,
     timescale_analytics_experimental.average(
         timescale_analytics_experimental.time_weight(time_weight)
     )
@@ -102,21 +106,21 @@ GROUP BY measure_id
 
 ## Command List (A-Z) [](time-weighted-average-api)
 > - [time_weight() (point form)](#time_weight_point)
-> - [time_weight() (summary form)](#time-weight-summary) 
+> - [time_weight() (summary form)](#time-weight-summary)
 > - [average()](#time-weight-average)
 
 ---
 ## **time_weight() (point form)** [](time_weight_point)
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.time_weight(
     method TEXT¹,
     ts TIMESTAMPTZ,
     value DOUBLE PRECISION
 ) RETURNS TimeWeightSummary
 ```
-¹ Only two values are currently supported, 'linear' and 'LOCF', any capitalization of these will be accepted. [See interpolation methods for more info.](#time-weight-methods) 
+¹ Only two values are currently supported, 'linear' and 'LOCF', any capitalization of these will be accepted. [See interpolation methods for more info.](#time-weight-methods)
 
-An aggregate that produces a `TimeWeightSummary` from timestamps and associated values. 
+An aggregate that produces a `TimeWeightSummary` from timestamps and associated values.
 
 ### Required Arguments² [](time-weight-point-required-arguments)
 |Name| Type |Description|
@@ -136,23 +140,23 @@ An aggregate that produces a `TimeWeightSummary` from timestamps and associated 
 <br>
 
 ### Sample Usage
-```SQL
+```SQL ,ignore
 WITH t as (
-    SELECT 
-        time_bucket('1 day'::interval, ts) as dt,   
+    SELECT
+        time_bucket('1 day'::interval, ts) as dt,
         timescale_analytics_experimental.time_weight('Linear', ts, val) AS tw -- get a time weight summary
     FROM foo
     WHERE id = 'bar'
     GROUP BY time_bucket('1 day'::interval, ts)
-) 
-SELECT 
-    dt, 
+)
+SELECT
+    dt,
     timescale_analytics_experimental.average(tw) -- extract the average from the time weight summary
 FROM t;
 ```
 
 ## **time_weight() (summary form)** [](time-weight-summary)
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.time_weight(
     tws TimeWeightSummary
 ) RETURNS TimeWeightSummary
@@ -173,10 +177,10 @@ An aggregate to compute a combined `TimeWeightSummary` from a series of non-over
 <br>
 
 ### Sample Usage
-```SQL
+```SQL ,ignore
 WITH t as (
-    SELECT 
-        date_trunc('day', ts) as dt,   
+    SELECT
+        date_trunc('day', ts) as dt,
         timescale_analytics_experimental.time_weight('Linear', ts, val) AS tw -- get a time weight summary
     FROM foo
     WHERE id = 'bar'
@@ -185,15 +189,15 @@ WITH t as (
     SELECT timescale_analytics_experimental.time_weight(tw) AS full_tw -- do a second level of aggregation to get the full time weighted average
     FROM t
 )
-SELECT 
-    dt, 
+SELECT
+    dt,
     timescale_analytics_experimental.average(tw),  -- extract the average from the time weight summary
     timescale_analytics_experimental.average(tw) / (SELECT full_tw FROM q LIMIT 1)  as normalized -- get the normalized average
 FROM t;
 ```
 
 ## **average()** [](time-weight-average)
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.average(
     tws TimeWeightSummary
 ) RETURNS DOUBLE PRECISION
@@ -215,27 +219,27 @@ A function to compute a time weighted average from a `TimeWeightSummary`.
 
 ### Sample Usage
 
-```SQL
-SELECT 
-    id,  
-    timescale_analytics_experimental.average(tws) 
+```SQL ,ignore
+SELECT
+    id,
+    timescale_analytics_experimental.average(tws)
 FROM (
-    SELECT 
-        id, 
-        timescale_analytics_experimental.time_weight('LOCF', ts, val) AS tws 
-    FROM foo 
+    SELECT
+        id,
+        timescale_analytics_experimental.time_weight('LOCF', ts, val) AS tws
+    FROM foo
     GROUP BY id
 ) t
 ```
 ---
 ## Notes on Parallelism and Ordering [](time-weight-ordering)
 
-The time weighted average calculations we perform require a strict ordering of inputs and therefore the calculations are not parallelizable in the strict Postgres sense. This is because when Postgres does parallelism it hands out rows randomly, basically as it sees them to workers. However, if your parallelism can guarantee disjoint (in time) sets of rows, the algorithm can be parallelized, just so long as within some time range, all rows go to the same worker. This is the case for both [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates) and for [distributed hypertables](https://docs.timescale.com/latest/using-timescaledb/distributed-hypertables) (as long as the partitioning keys are in the group by, though the aggregate itself doesn't horribly make sense otherwise). 
+The time weighted average calculations we perform require a strict ordering of inputs and therefore the calculations are not parallelizable in the strict Postgres sense. This is because when Postgres does parallelism it hands out rows randomly, basically as it sees them to workers. However, if your parallelism can guarantee disjoint (in time) sets of rows, the algorithm can be parallelized, just so long as within some time range, all rows go to the same worker. This is the case for both [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates) and for [distributed hypertables](https://docs.timescale.com/latest/using-timescaledb/distributed-hypertables) (as long as the partitioning keys are in the group by, though the aggregate itself doesn't horribly make sense otherwise).
 
 We throw an error if there is an attempt to combine overlapping `TimeWeightSummaries`, for instance, in our example above, if you were to try to combine summaries across `measure_id`s it would error. This is because the interpolation techniques really only make sense within a given time series determined by a single `measure_id`. However, given that the time weighted average produced is a dimensionless quantity, a simple average of time weighted average should better represent the variation across devices, so the recommendation for things like baselines across many timeseries would be something like:
 
-```SQL
-WITH t as (SELECT measure_id, 
+```SQL ,ignore
+WITH t as (SELECT measure_id,
         timescale_analytics_experimental.average(
             timescale_analytics_experimental.time_weight('LOCF', ts, val)
         ) as time_weighted_average
@@ -245,18 +249,18 @@ SELECT avg(time_weighted_average) -- use the normal avg function to average our 
 FROM t;
 ```
 
-Internally, the first and last points seen as well as the calculated weighted sum are stored in each `TimeWeightSummary` and used to combine with a neighboring `TimeWeightSummary` when re-aggregation or the Postgres `combine function` is called. In general, the functions support [partial aggregation](https://www.postgresql.org/docs/current/xaggr.html#XAGGR-PARTIAL-AGGREGATES) and partitionwise aggregation in the multinode context, but are not parallelizable (in the Postgres sense, which requires them to accept potentially overlapping input). 
+Internally, the first and last points seen as well as the calculated weighted sum are stored in each `TimeWeightSummary` and used to combine with a neighboring `TimeWeightSummary` when re-aggregation or the Postgres `combine function` is called. In general, the functions support [partial aggregation](https://www.postgresql.org/docs/current/xaggr.html#XAGGR-PARTIAL-AGGREGATES) and partitionwise aggregation in the multinode context, but are not parallelizable (in the Postgres sense, which requires them to accept potentially overlapping input).
 
 Because they require ordered sets, the aggregates build up a buffer of input data, sort it and then perform the proper aggregation steps. In cases where memory is proving to be too small to build up a buffer of points causing OOMs or other issues, a multi-level aggregate can be useful. Following our example from above:
 
-```SQL
-WITH t as (SELECT measure_id, 
+```SQL ,ignore
+WITH t as (SELECT measure_id,
     time_bucket('1 day'::interval, ts),
     timescale_analytics_experimental.time_weight('LOCF', ts, val)
     FROM foo
     GROUP BY measure_id, time_bucket('1 day'::interval, ts)
     )
-SELECT measure_id, 
+SELECT measure_id,
     timescale_analytics_experimental.average(
         timescale_analytics_experimental.time_weight(time_weight)
     )
@@ -264,24 +268,24 @@ FROM t
 GROUP BY measure_id;
 ```
 
-Moving aggregate mode is not supported by `time_weight` and its use as a window function may be quite inefficient. 
+Moving aggregate mode is not supported by `time_weight` and its use as a window function may be quite inefficient.
 
 ---
 ## Interpolation Methods Details [](time-weight-methods)
 
-Discrete time values don't always allow for an obvious calculation of the time weighted average. In order to calculate a time weighted average we need to choose how to weight each value. The two methods we currently use are last observation carried forward (LOCF) and linear interpolation. 
+Discrete time values don't always allow for an obvious calculation of the time weighted average. In order to calculate a time weighted average we need to choose how to weight each value. The two methods we currently use are last observation carried forward (LOCF) and linear interpolation.
 
-In the LOCF approach, the value is treated as if it remains constant until the next value is seen. The LOCF approach is commonly used when the sensor or measurement device sends measurement only when there is a change in value. 
+In the LOCF approach, the value is treated as if it remains constant until the next value is seen. The LOCF approach is commonly used when the sensor or measurement device sends measurement only when there is a change in value.
 
-The linear interpolation approach treats the values between any two measurements as if they lie on the line connecting the two measurements. The linear interpolation approach is used to account for irregularly sampled data where the sensor doesn't provide any guarantees 
+The linear interpolation approach treats the values between any two measurements as if they lie on the line connecting the two measurements. The linear interpolation approach is used to account for irregularly sampled data where the sensor doesn't provide any guarantees
 
 Essentially, internally, the time weighted average computes a numerical approximation of the integral of the theoretical full time curve based on the discrete sampled points provided. We call this the weighted sum.  For LOCF, the the weighted sum will be equivalent to the area under a stepped curve:
 ```
 
-|                        (pt 4)   
+|                        (pt 4)
 |          (pt 2)          *
 |            *-------      |
-|            |       |     | 
+|            |       |     |
 |(pt 1)      |       *------
 |  *---------      (pt 3)  |
 |  |                       |
@@ -290,16 +294,16 @@ Essentially, internally, the time weighted average computes a numerical approxim
 ```
 The linear interpolation is similar, except here it is more of a sawtooth curve. (And the points are different due to the limitations of the slopes of lines one can "draw" using ASCII art).
 ```
-|                      (pt 4) 
-|                        *      
-|           (pt 2)     / |     
+|                      (pt 4)
+|                        *
+|           (pt 2)     / |
 |            *       /   |
-|          /   \   /     | 
-|(pt 1)  /       *       | 
+|          /   \   /     |
+|(pt 1)  /       *       |
 |      *      (pt 3)     |
-|      |                 | 
+|      |                 |
 |______|_________________|____________
              time
 ```
 
-Here this ends up being equal to the rectangle with width equal to the duration between two points and height the midpoint between the two magnitudes. Once we have this weighted sum, we can divide by the total duration to get the time weighted average. 
+Here this ends up being equal to the rectangle with width equal to the duration between two points and height the midpoint between the two magnitudes. Once we have this weighted sum, we can divide by the total duration to get the time weighted average.

--- a/extension/docs/uddsketch.md
+++ b/extension/docs/uddsketch.md
@@ -21,8 +21,10 @@ Timescale's UddSketch implementation is provided as an aggregate function in Pos
 
 For this example we're going to start with a table containing some NOAA weather data for a few weather stations across the US over the past 20 years.
 
-```SQL
-timescale_analytics=> \d weather;
+```SQL ,ignore
+\d weather;
+```
+```
                          Table "public.weather"
  Column  |            Type             | Collation | Nullable | Default
 ---------+-----------------------------+-----------+----------+---------
@@ -38,17 +40,19 @@ timescale_analytics=> \d weather;
 
 Now let's create some UddSketches for our different stations and verify that they're receiving data.
 
-```SQL
-timescale_analytics=> CREATE VIEW daily_rain AS
+```SQL ,ignore
+CREATE VIEW daily_rain AS
     SELECT name, timescale_analytics_experimental.uddsketch(100, 0.005, prcp)
     FROM weather
     GROUP BY name;
-CREATE VIEW
-timescale_analytics=> SELECT
+
+SELECT
     name,
     timescale_analytics_experimental.get_count(uddsketch),
     timescale_analytics_experimental.error(uddsketch)
 FROM daily_rain;
+```
+```
                  name                  | get_count |               error
 ---------------------------------------+-----------+---------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US |      7671 |  0.0199975003624472
@@ -61,11 +65,13 @@ FROM daily_rain;
 Notice that 100 buckets proved to be insufficient to maintain 0.5% relative error for three of our data sets, but they've automatically adjusted their bucket size to maintain the desired bucket limit.
 
 We can then check some rainfall quantiles to see how our stations compare.
-```SQL
-timescale_analytics=> SELECT
+```SQL ,ignore
+SELECT
     name,
     timescale_analytics_experimental.quantile(uddsketch, 0.6)
 FROM daily_rain;
+```
+```
                  name                  |             quantile
 ---------------------------------------+----------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 0.009850446542334412
@@ -73,11 +79,14 @@ FROM daily_rain;
  NY CITY CENTRAL PARK, NY US           |                    0
  MIAMI INTERNATIONAL AIRPORT, FL US    |                    0
 (4 rows)
-
-timescale_analytics=> SELECT
+```
+```SQL ,ignore
+SELECT
     name,
     timescale_analytics_experimental.quantile(uddsketch, 0.9)
 FROM daily_rain;
+```
+```
                  name                  |           quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 0.3072142710699281
@@ -85,11 +94,14 @@ FROM daily_rain;
  NY CITY CENTRAL PARK, NY US           | 0.4672895773464223
  MIAMI INTERNATIONAL AIRPORT, FL US    | 0.5483701300878486
 (4 rows)
-
-timescale_analytics=> SELECT
+```
+```SQL ,ignore
+SELECT
     name,
     timescale_analytics_experimental.quantile(uddsketch, 0.995)
 FROM daily_rain;
+```
+```
                  name                  |           quantile
 ---------------------------------------+--------------------
  PORTLAND INTERNATIONAL AIRPORT, OR US | 1.1969797510556823
@@ -110,7 +122,7 @@ FROM daily_rain;
 
 ---
 ## **uddsketch** [](uddsketch)
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.uddsketch(
     size INTEGER,
     max_error DOUBLE PRECISION,
@@ -138,13 +150,13 @@ This will construct and return a new UddSketch with at most `size` buckets.  The
 ### Sample Usages [](uddsketch-examples)
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a sketch over that column
 
-```SQL
+```SQL ,ignore
 SELECT timescale_analytics_experimental.uddsketch(100, 0.01, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other uddsketch functions.
 
-```SQL
+```SQL ,ignore
 CREATE VIEW sketch AS
     SELECT timescale_analytics_experimental.uddsketch(100, 0.01, data)
     FROM samples;
@@ -153,7 +165,7 @@ CREATE VIEW sketch AS
 ---
 ## **uddsketch_count** [](uddsketch_count)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.get_count(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
@@ -177,17 +189,18 @@ Get the number of values contained in a UddSketch.
 SELECT timescale_analytics_experimental.get_count(
     timescale_analytics_experimental.uddsketch(100, 0.01, data)
 ) FROM generate_series(1, 100) data;
+```
+```output
  get_count
 -----------
        100
-(1 row)
 ```
 
 ---
 
 ## **uddsketch_error** [](uddsketch_error)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.error(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
@@ -212,16 +225,17 @@ This returns the maximum relative error that a quantile estimate will have (rela
 SELECT timescale_analytics_experimental.error(
     timescale_analytics_experimental.uddsketch(100, 0.01, data)
 ) FROM generate_series(1, 100) data;
+```
+```output
  error
 -------
   0.01
-(1 row)
 ```
 
 ---
 ## **uddsketch_mean** [](uddsketch_mean)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.mean(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
 
@@ -245,16 +259,17 @@ Get the average of all the values contained in a UddSketch.
 SELECT timescale_analytics_experimental.mean(
     timescale_analytics_experimental.uddsketch(100, 0.01, data)
 ) FROM generate_series(1, 100) data;
+```
+```output
  mean
 ------
  50.5
-(1 row)
 ```
 
 ---
 ## **uddsketch_quantile** [](uddsketch_quantile)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.quantile(
     sketch UddSketch,
     quantile DOUBLE PRECISION
@@ -283,16 +298,17 @@ SELECT timescale_analytics_experimental.quantile(
     timescale_analytics_experimental.uddsketch(100, 0.01, data),
     0.90
 ) FROM generate_series(1, 100) data;
+```
+```output
            quantile
 --------------------
   89.13032933635797
-(1 row)
 ```
 
 ---
 ## **uddsketch_quantile_at_value** [](uddsketch_quantile_at_value)
 
-```SQL
+```SQL ,ignore
 timescale_analytics_experimental.quantile_at_value(
     sketch UddSketch,
     value DOUBLE PRECISION
@@ -318,11 +334,12 @@ Estimate what quantile a given value would be located at in a UddSketch.
 
 ```SQL
 SELECT timescale_analytics_experimental.quantile_at_value(
-    uddsketch(100, 0.01, data),
+    timescale_analytics_experimental.uddsketch(100, 0.01, data),
     90
 ) FROM generate_series(1, 100) data;
+```
+```output
  quantile_at_value
 -------------------
              0.89
-(1 row)
 ```

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -3,6 +3,3 @@ hyperloglog.generated.sql
 uddsketch.generated.sql
 triggers.generated.sql
 time_weighted_average.generated.sql
-schema_test.generated.sql
-serialization_collations.generated.sql
-serialization_types.generated.sql

--- a/tools/sql-doctester/Cargo.toml
+++ b/tools/sql-doctester/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sql-doctester"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+bytecount = "0.6.2"
+clap = { version = "2.33", features = ["wrap_help"] }
+colored = "2.0.0"
+postgres = "0.19.0"
+pulldown-cmark = "0.8.0"
+rayon = "1.5"
+uuid = { version = "0.8", features = ["v4"] }
+walkdir = "2"

--- a/tools/sql-doctester/Readme.md
+++ b/tools/sql-doctester/Readme.md
@@ -1,0 +1,146 @@
+## SQL Doctester ##
+
+Test SQL code in Markdown files.
+
+This tool looks through a directory for markdown files containing SQL, runs any
+examples it finds, and validates its output. For instance, when run against this
+file it will validate that the following SQL runs correctly:
+
+```SQL
+SELECT count(v), sum(v), avg(v) FROM generate_series(1, 10) v;
+```
+```output
+ count | sum |                avg
+ ------+-----+--------------------
+    10 |  55 | 5.5000000000000000
+```
+
+If we were to have errors in the example, for instance, we `count` and `sum`
+swapped, the tool will report the errors, and where the output differs from the
+expected output, like so:
+
+```
+Tests Failed
+
+Readme.md:9 `SQL Doctester`
+
+SELECT count(v), sum(v), avg(v) FROM generate_series(1, 10) v;
+
+Error: output has a different values than expected.
+Expected
+55 | 10 | 5.5000000000000000
+(1 rows)
+
+Received
+10 | 55 | 5.5000000000000000
+(1 rows)
+
+Delta
+-55+10 | -10+55 | 5.5000000000000000
+```
+
+## Installation ##
+
+```bash
+cargo install --git https://github.com/timescale/timescale-analytics.git --branch main sql-doctester
+```
+
+## Usage ##
+
+```
+sql-doctester
+
+USAGE:
+    sql-doctester [OPTIONS] <tests>
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --database <database>
+            postgres database the root connection should use. By default this DB will only be used
+            to spawn the individual test databases; no tests will run against it.
+    -h, --host <hostname>                    postgres host
+    -a, --password <password>                postgres password
+    -p, --port <portnumber>                  postgres port
+    -f, --startup-file <startup_file>
+            File containing SQL commands that should be run when each test database is created.
+
+    -s, --startup-script <startup_script>
+            SQL command that should be run when each test database is created.
+
+    -u, --user <username>                    postgres user
+
+ARGS:
+    <tests>    Path in which to search for tests
+```
+
+## Formatting ##
+
+The tool looks through every markdown file in the provided path for SQL code
+blocks like
+
+    ```SQL
+    SELECT column_1, column_2, etc FROM foo
+    ```
+
+and will try to run them. The SQL is assumed to be followed with an `output`
+block like which contains the expected output for the command
+
+    ```output
+     column 1 | column 2 | etc
+    ----------+----------+-----
+      value 1 |  value 1 | etc
+    ```
+
+Only the actual values are checked; the header, along with leading and trailing
+whitespace are ignored. If no `output` is provided the tester will validate that
+the output should be empty.
+
+Output validation can be suppressed by adding `ignore-output` after
+the `SQL` tag, like so
+
+    ```SQL,ignore-output
+    SELECT non_validated FROM foo
+    ```
+in which case the SQL will be run, and its output ignored.
+
+SQL code blocks can be skipped entirely be adding `ignore` after the tag as in
+
+    ```SQL,ignore
+    This never runs, so it doesn't matter if it's valid SQL
+    ```
+
+By default, each code block is run in its own transaction, which is rolled back
+after the command completes. If you want to run outside a transaction, because
+you're running commands that cannot be run within a transaction, or because you
+want to change global state, you can mark a block as non-transactional like so
+
+    ```SQL,non-transactional
+    CREATE TABLE bar();
+    ```
+
+Every file is run in its own database, so such commands can only affect the
+remainder of the current file. This tag can be combined with any of the others.
+
+The tool supports adding startup scripts that are run first on every new
+database. This can be useful for repetitive initialization tasks, like CREATEing
+extensions that must be done for every file. For file-specific initialization,
+you can you `non-transactional` blocks. These blocks can be hidden `<div>` like
+so
+
+    <div hidden>
+
+    ```SQL,non-transactional
+    CREATE TABLE data()
+    ```
+
+    </div>
+
+if you want them to be invisible to readers.
+
+## Acknowledgements ##
+
+Inspired by [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)
+and [rust-skeptic](https://github.com/budziq/rust-skeptic).

--- a/tools/sql-doctester/src/main.rs
+++ b/tools/sql-doctester/src/main.rs
@@ -1,0 +1,128 @@
+use std::{
+    borrow::Cow,
+    ffi::OsStr,
+    fs,
+    io::{self, Write},
+    process::exit,
+};
+
+use clap::clap_app;
+
+use colored::Colorize;
+
+use runner::ConnectionConfig;
+
+mod parser;
+mod runner;
+
+fn main() {
+    let matches = clap_app!(("sql-doctester") =>
+        (@arg HOST: -h --host [hostname] conflicts_with[URL] "postgres host")
+        (@arg PORT: -p --port [portnumber] conflicts_with[URL] "postgres port")
+        (@arg USER: -u --user [username] conflicts_with[URL] "postgres user")
+        (@arg PASSWORD: -a --password [password] conflicts_with[URL] "postgres password")
+        (@arg DB: -d --database [database] conflicts_with[URL] "postgres database the root \
+            connection should use. By default this DB will only be used \
+            to spawn the individual test databases; no tests will run against \
+            it.")
+        (@arg START_SCRIPT: -s --("startup-script") [startup_script] conflicts_with[START_FILE] "SQL command that should be run when each test database is created.")
+        (@arg START_FILE: -f --("startup-file") [startup_file] "File containing SQL commands that should be run when each test database is created.")
+        (@arg INPUT: <tests>  "Path in which to search for tests")
+    ).get_matches();
+    let dirname = matches.value_of("INPUT").expect("need input");
+
+    let connection_config = ConnectionConfig {
+        host: matches.value_of("HOST"),
+        port: matches.value_of("PORT"),
+        user: matches.value_of("USER"),
+        password: matches.value_of("PASSWORD"),
+        database: matches.value_of("DB"),
+    };
+
+    let startup_script = match matches.value_of("START_SCRIPT") {
+        Some(script) => Some(Cow::Borrowed(script)),
+        None => matches.value_of("START_FILE").map(|file| {
+            let contents = fs::read_to_string(file).expect("cannot read script file");
+            Cow::Owned(contents)
+        }),
+    };
+
+    let all_tests = extract_tests(dirname);
+
+    let mut num_errors = 0;
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    let on_error = |test: Test, error: runner::TestError| {
+        if num_errors == 0 {
+            let _ = writeln!(&mut out, "{}\n", "Tests Failed".bold().red());
+        }
+        num_errors += 1;
+        let _ = writeln!(
+            &mut out,
+            "{} {}\n",
+            test.location.bold().blue(),
+            test.header.bold().dimmed()
+        );
+        let _ = writeln!(&mut out, "{}", error.annotate_position(&test.text));
+        let _ = writeln!(&mut out, "{}\n", error);
+    };
+
+    runner::run_tests(connection_config, startup_script, all_tests, on_error);
+    if num_errors > 0 {
+        exit(1)
+    }
+    let _ = writeln!(&mut out, "{}\n", "Tests Passed".bold().green());
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub struct TestFile {
+    name: String,
+    stateless: bool,
+    tests: Vec<Test>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub struct Test {
+    location: String,
+    header: String,
+    text: String,
+    output: Vec<Vec<String>>,
+    transactional: bool,
+    ignore_output: bool,
+}
+
+fn extract_tests(root: &str) -> Vec<TestFile> {
+    // TODO handle when root is a file
+    let mut all_tests = vec![];
+    let walker = walkdir::WalkDir::new(root)
+        .follow_links(true)
+        .sort_by(|a, b| a.path().cmp(b.path()));
+    for entry in walker {
+        let entry = entry.unwrap();
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        if entry.path().extension() != Some(OsStr::new("md")) {
+            continue;
+        }
+
+        let realpath;
+        let path = if entry.file_type().is_symlink() {
+            realpath = fs::read_link(entry.path()).unwrap();
+            &*realpath
+        } else {
+            entry.path()
+        };
+        let contents = fs::read_to_string(path).unwrap();
+
+        let tests = parser::extract_tests_from_string(&*contents, &*entry.path().to_string_lossy());
+        if !tests.tests.is_empty() {
+            all_tests.push(tests)
+        }
+    }
+    all_tests
+}

--- a/tools/sql-doctester/src/parser.rs
+++ b/tools/sql-doctester/src/parser.rs
@@ -1,0 +1,318 @@
+use pulldown_cmark::{
+    CodeBlockKind::Fenced,
+    CowStr, Event, Parser,
+    Tag::{CodeBlock, Heading},
+};
+
+use crate::{Test, TestFile};
+
+// parsers the grammar `(heading* (test output?)*)*`
+pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
+    let mut parser = Parser::new(s).into_offset_iter().peekable();
+    let mut heading_stack = vec![];
+    let mut tests = vec![];
+
+    let mut last_test_seen_at = 0;
+    let mut lines_seen = 0;
+
+    let mut stateless = true;
+
+    // consume the parser until an tag is reached, performing an action on each text
+    macro_rules! consume_text_until {
+        ($parser: ident yields $end: pat => $action: expr) => {
+            for (event, _) in &mut parser {
+                match event {
+                    Event::Text(text) => $action(text),
+                    $end => break,
+                    _ => (),
+                }
+            }
+        };
+    }
+
+    'block_hunt: while let Some((event, span)) = parser.next() {
+        match event {
+            // we found a heading, add it to the stack
+            Event::Start(Heading(level)) => {
+                heading_stack.truncate(level as usize - 1);
+                let mut header = "`".to_string();
+                consume_text_until!(parser yields Event::End(Heading(..)) =>
+                    |text: CowStr| header.push_str(&*text)
+                );
+                header.truncate(header.trim_end().len());
+                header.push('`');
+                heading_stack.push(header);
+            }
+
+            // we found a code block, if it's a test add the test
+            Event::Start(CodeBlock(Fenced(ref info))) => {
+                let code_block_info = parse_code_block_info(info);
+
+                // non-test code block, consume it and continue looking
+                if let BlockKind::Other = code_block_info.kind {
+                    for (event, _) in &mut parser {
+                        if let Event::End(CodeBlock(Fenced(..))) = event {
+                            break;
+                        }
+                    }
+                    continue 'block_hunt;
+                }
+
+                let current_line = {
+                    let offset = span.start;
+                    lines_seen += bytecount::count(&s.as_bytes()[last_test_seen_at..offset], b'\n');
+                    last_test_seen_at = offset;
+                    lines_seen + 1
+                };
+
+                if let BlockKind::Output = code_block_info.kind {
+                    panic!(
+                        "found output with no test test.\n{}:{} {:?}",
+                        file_stem, current_line, heading_stack
+                    )
+                }
+
+                assert!(matches!(code_block_info.kind, BlockKind::SQL));
+
+                stateless &= code_block_info.transactional;
+                let mut test = Test {
+                    location: format!("{}:{}", file_stem, current_line),
+                    header: if heading_stack.is_empty() {
+                        "<root>".to_string()
+                    } else {
+                        heading_stack.join("::")
+                    },
+                    text: String::new(),
+                    output: Vec::new(),
+                    transactional: code_block_info.transactional,
+                    ignore_output: code_block_info.ignore_output,
+                };
+
+                // consume the lines of the test
+                consume_text_until!(parser yields Event::End(CodeBlock(Fenced(..))) =>
+                    |text: CowStr| test.text.push_str(&*text)
+                );
+
+                // search to see if we have output
+                loop {
+                    match parser.peek() {
+                        // we found a code block, is it output?
+                        Some((Event::Start(CodeBlock(Fenced(info))), _)) => {
+                            let code_block_info = parse_code_block_info(info);
+                            match code_block_info.kind {
+                                // non-output, continue at the top
+                                BlockKind::SQL | BlockKind::Other => {
+                                    tests.push(test);
+                                    continue 'block_hunt;
+                                }
+
+                                // output, consume it
+                                BlockKind::Output => {
+                                    let _ = parser.next();
+                                    break;
+                                }
+                            }
+                        }
+
+                        // test must be over, continue at the top
+                        Some((Event::Start(CodeBlock(..)), _))
+                        | Some((Event::Start(Heading(..)), _)) => {
+                            tests.push(test);
+                            continue 'block_hunt;
+                        }
+
+                        // EOF, we're done
+                        None => {
+                            tests.push(test);
+                            break 'block_hunt;
+                        }
+
+                        // for now we allow text between the test and it's output
+                        // TODO should/can we forbid this?
+                        _ => {
+                            let _ = parser.next();
+                        }
+                    };
+                }
+
+                // consume the output
+                consume_text_until!(parser yields Event::End(CodeBlock(Fenced(..))) =>
+                    |text: CowStr| {
+                        let rows = text.split('\n').skip(2).filter(|s| !s.is_empty()).map(|s|
+                            s.split('|').map(|s| s.trim().to_string()).collect::<Vec<_>>()
+                        );
+                        test.output.extend(rows);
+                    }
+                );
+
+                tests.push(test);
+            }
+
+            _ => (),
+        }
+    }
+    TestFile {
+        name: file_stem.to_string(),
+        stateless,
+        tests,
+    }
+}
+
+struct CodeBlockInfo {
+    kind: BlockKind,
+    transactional: bool,
+    ignore_output: bool,
+}
+
+#[derive(Clone, Copy)]
+enum BlockKind {
+    SQL,
+    Output,
+    Other,
+}
+
+fn parse_code_block_info(info: &str) -> CodeBlockInfo {
+    let tokens = info.split(',');
+
+    let mut info = CodeBlockInfo {
+        kind: BlockKind::Other,
+        transactional: true,
+        ignore_output: false,
+    };
+
+    for token in tokens {
+        match token.trim() {
+            "ignore" => {
+                if let BlockKind::SQL = info.kind {
+                    info.kind = BlockKind::Other;
+                }
+            }
+            "non-transactional" => info.transactional = false,
+            "ignore-output" => info.ignore_output = true,
+            "output" => info.kind = BlockKind::Output,
+            s if s.to_ascii_lowercase() == "sql" => info.kind = BlockKind::SQL,
+            _ => {}
+        }
+    }
+
+    info
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn extract() {
+        use super::{Test, TestFile};
+
+        let file = r##"
+# Test Parsing
+```SQL
+select * from foo
+```
+```output
+```
+
+```SQL
+select * from multiline
+```
+```output
+ ?column?
+----------
+    value
+```
+
+## ignored
+```SQL,ignore
+select * from foo
+```
+
+## non-transactional
+```SQL,non-transactional
+select * from bar
+```
+```output
+ a | b
+---+---
+ 1 | 2
+```
+
+## no output
+```SQL,ignore-output
+select * from baz
+```
+
+## end by header
+```SQL
+select * from quz
+```
+
+## end by file
+```SQL
+select * from qat
+```
+"##;
+
+        let tests = super::extract_tests_from_string(file, "/test/file.md");
+        let expected = TestFile {
+            name: "/test/file.md".to_string(),
+            stateless: false,
+            tests: vec![
+                Test {
+                    location: "/test/file.md:3".to_string(),
+                    header: "`Test Parsing`".to_string(),
+                    text: "select * from foo\n".to_string(),
+                    output: vec![],
+                    transactional: true,
+                    ignore_output: false,
+                },
+                Test {
+                    location: "/test/file.md:9".to_string(),
+                    header: "`Test Parsing`".to_string(),
+                    text: "select * from multiline\n".to_string(),
+                    output: vec![vec!["value".to_string()]],
+                    transactional: true,
+                    ignore_output: false,
+                },
+                Test {
+                    location: "/test/file.md:24".to_string(),
+                    header: "`Test Parsing`::`non-transactional`".to_string(),
+                    text: "select * from bar\n".to_string(),
+                    output: vec![vec!["1".to_string(), "2".to_string()]],
+                    transactional: false,
+                    ignore_output: false,
+                },
+                Test {
+                    location: "/test/file.md:34".to_string(),
+                    header: "`Test Parsing`::`no output`".to_string(),
+                    text: "select * from baz\n".to_string(),
+                    output: vec![],
+                    transactional: true,
+                    ignore_output: true,
+                },
+                Test {
+                    location: "/test/file.md:39".to_string(),
+                    header: "`Test Parsing`::`end by header`".to_string(),
+                    text: "select * from quz\n".to_string(),
+                    output: vec![],
+                    transactional: true,
+                    ignore_output: false,
+                },
+                Test {
+                    location: "/test/file.md:44".to_string(),
+                    header: "`Test Parsing`::`end by file`".to_string(),
+                    text: "select * from qat\n".to_string(),
+                    output: vec![],
+                    transactional: true,
+                    ignore_output: false,
+                },
+            ],
+        };
+        assert!(
+            tests == expected,
+            "left: {:#?}\n right: {:#?}",
+            tests,
+            expected
+        );
+    }
+}

--- a/tools/sql-doctester/src/runner.rs
+++ b/tools/sql-doctester/src/runner.rs
@@ -1,0 +1,386 @@
+use rayon::{iter::ParallelIterator, prelude::*};
+
+use std::{borrow::Cow, error::Error, fmt};
+
+use colored::Colorize;
+
+use postgres::{error::DbError, Client, NoTls, SimpleQueryMessage};
+use uuid::Uuid;
+
+use crate::{Test, TestFile};
+
+#[derive(Copy, Clone)]
+pub struct ConnectionConfig<'s> {
+    pub host: Option<&'s str>,
+    pub port: Option<&'s str>,
+    pub user: Option<&'s str>,
+    pub password: Option<&'s str>,
+    pub database: Option<&'s str>,
+}
+
+impl<'s> ConnectionConfig<'s> {
+    fn to_config_string(&self) -> Cow<'s, str> {
+        use std::fmt::Write;
+
+        let ConnectionConfig {
+            host,
+            port,
+            user,
+            password,
+            database,
+        } = self;
+        let mut config = String::new();
+        if let Some(host) = host {
+            let _ = write!(&mut config, "host={} ", host);
+        }
+        if let Some(port) = port {
+            let _ = write!(&mut config, "port={} ", port);
+        }
+        let _ = match user {
+            Some(user) => write!(&mut config, "user={} ", user),
+            None => write!(&mut config, "user=postgres "),
+        };
+        if let Some(password) = password {
+            let _ = write!(&mut config, "password={} ", password);
+        }
+        if let Some(database) = database {
+            let _ = write!(&mut config, "dbname={} ", database);
+        }
+        Cow::Owned(config)
+    }
+}
+
+pub fn run_tests<OnErr: FnMut(Test, TestError)>(
+    connection_config: ConnectionConfig<'_>,
+    startup_script: Option<Cow<'_, str>>,
+    all_tests: Vec<TestFile>,
+    mut on_error: OnErr,
+) {
+    let startup_script = startup_script.as_ref().map(|s| &**s);
+    let root_connection_config = connection_config.to_config_string();
+    let root_connection_config = &*root_connection_config;
+    eprintln!("running {} test files", all_tests.len());
+
+    let start_db = |tests_name: &str| {
+        let db_name = format!("doctest_db__{}", Uuid::new_v4());
+        let finish_name = tests_name.to_string();
+        let drop_name = db_name.to_string();
+        let deferred = Deferred(move || {
+            eprintln!("{} {}", "Finished".bold().green(), finish_name);
+            let mut dropper = Client::connect(root_connection_config, NoTls)
+                .expect("cannot connect to drop test DBs");
+            dropper
+                .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{}""#, drop_name))
+                .expect("could not drop test DB");
+        });
+        {
+            eprintln!("{} {}", "Starting".bold().green(), tests_name);
+            let mut root_client = Client::connect(root_connection_config, NoTls)
+                .expect("could not connect to postgres");
+            root_client
+                .simple_query(&format!(r#"CREATE DATABASE "{}""#, db_name))
+                .expect("could not create test DB");
+        }
+        (db_name, deferred)
+    };
+
+    let (stateless_db, _dropper) = match all_tests.iter().any(|t| t.stateless) {
+        false => (None, None),
+        true => {
+            let (name, dropper) = start_db("stateless tests");
+            (Some(name), Some(dropper))
+        }
+    };
+
+    if let (Some(db), Some(startup_script)) = (stateless_db.as_ref(), startup_script) {
+        let stateless_connection_config = ConnectionConfig {
+            database: Some(&*db),
+            ..connection_config
+        };
+        let mut client = Client::connect(&stateless_connection_config.to_config_string(), NoTls)
+            .expect("could not connect to test DB");
+        let _ = client
+            .simple_query(startup_script)
+            .expect("could not run init script");
+    }
+
+    let stateless_db = stateless_db.as_ref();
+
+    let errors: Vec<_> = all_tests
+        .into_par_iter()
+        .flat_map_iter(|tests| {
+            let (db_name, deferred) = match tests.stateless {
+                true => {
+                    eprintln!("{} {}", "Running".bold().green(), tests.name);
+                    (stateless_db.map(|s| Cow::Borrowed(&**s)), None)
+                }
+                false => {
+                    let (db_name, deferred) = start_db(&*tests.name);
+                    (Some(Cow::Owned(db_name)), Some(deferred))
+                }
+            };
+
+            let test_connection_config = ConnectionConfig {
+                database: db_name.as_ref().map(|n| &**n),
+                ..connection_config
+            };
+            let mut client = Client::connect(&test_connection_config.to_config_string(), NoTls)
+                .expect("could not connect to test DB");
+
+            if let (false, Some(startup_script)) = (tests.stateless, startup_script) {
+                let _ = client
+                    .simple_query(startup_script)
+                    .expect("could not run init script");
+            }
+
+            let deferred = deferred;
+
+            tests.tests.into_iter().map(move |test| {
+                let output = if test.transactional {
+                    run_transactional_test(&mut client, &test)
+                } else {
+                    run_nontransactional_test(&mut client, &test)
+                };
+                // ensure that the DB is dropped after the client
+                let _deferred = &deferred;
+                (test, output)
+            })
+        })
+        .collect();
+
+    drop(_dropper);
+
+    for (test, error) in errors {
+        match error {
+            Ok(..) => continue,
+            Err(error) => on_error(test, error),
+        }
+    }
+}
+
+fn run_transactional_test(client: &mut Client, test: &Test) -> Result<(), TestError> {
+    let mut txn = client.transaction()?;
+    let output = txn.simple_query(&test.text)?;
+    let res = validate_output(output, test);
+    txn.rollback()?;
+    res
+}
+
+fn run_nontransactional_test(client: &mut Client, test: &Test) -> Result<(), TestError> {
+    let output = client.simple_query(&test.text)?;
+    let res = validate_output(output, test);
+    res
+}
+
+fn validate_output(output: Vec<SimpleQueryMessage>, test: &Test) -> Result<(), TestError> {
+    use SimpleQueryMessage::*;
+    if test.ignore_output {
+        return Ok(());
+    }
+
+    let mut rows = Vec::with_capacity(test.output.len());
+    for r in output {
+        match r {
+            Row(r) => {
+                let mut row: Vec<String> = Vec::with_capacity(r.len());
+                for i in 0..r.len() {
+                    row.push(r.get(i).unwrap_or("").to_string())
+                }
+                rows.push(row);
+            }
+            CommandComplete(..) => break,
+            _ => unreachable!(),
+        }
+    }
+    let output_error = |header: &str| {
+        format!(
+            "{}\n{expected}\n{}{}\n\n{received}\n{}{}\n\n{delta}\n{}",
+            header,
+            stringify_table(&test.output),
+            format!("({} rows)", test.output.len()).dimmed(),
+            stringify_table(&rows),
+            format!("({} rows)", rows.len()).dimmed(),
+            stringify_delta(&test.output, &rows),
+            expected = "Expected".bold().blue(),
+            received = "Received".bold().blue(),
+            delta = "Delta".bold().blue(),
+        )
+    };
+    if test.output.len() != rows.len() {
+        return Err(TestError::OutputError(output_error(
+            "output has a different number of rows than expected.",
+        )));
+    }
+    if test.output != rows {
+        return Err(TestError::OutputError(output_error(
+            "output has a different values than expected.",
+        )));
+    }
+    Ok(())
+}
+
+fn stringify_table(table: &Vec<Vec<String>>) -> String {
+    use std::{cmp::max, fmt::Write};
+    if table.is_empty() {
+        return "---".to_string();
+    }
+    let mut width = vec![0; table[0].len()];
+    for row in table {
+        for (i, value) in row.iter().enumerate() {
+            width[i] = max(width[i], value.len())
+        }
+    }
+    let mut output = String::with_capacity(width.iter().sum::<usize>() + width.len() * 3);
+    for row in table {
+        for (i, value) in row.iter().enumerate() {
+            if i != 0 {
+                output.push_str(" | ")
+            }
+            let _ = write!(&mut output, "{:>width$}", value, width = width[i]);
+        }
+        output.push('\n')
+    }
+
+    output
+}
+
+fn stringify_delta(left: &Vec<Vec<String>>, right: &Vec<Vec<String>>) -> String {
+    use std::{cmp::max, fmt::Write};
+
+    static EMPTY_ROW: Vec<String> = vec![];
+    static EMPTY_VAL: String = String::new();
+
+    let mut width = vec![
+        0;
+        max(
+            left.get(0).map(Vec::len).unwrap_or(0),
+            right.get(0).map(Vec::len).unwrap_or(0)
+        )
+    ];
+    let num_rows = max(left.len(), right.len());
+    for i in 0..num_rows {
+        let left = left.get(i).unwrap_or(&EMPTY_ROW);
+        let right = right.get(i).unwrap_or(&EMPTY_ROW);
+        let cols = max(left.len(), right.len());
+        for j in 0..cols {
+            let left = left.get(j).unwrap_or(&EMPTY_VAL);
+            let right = right.get(j).unwrap_or(&EMPTY_VAL);
+            if left == right {
+                width[j] = max(width[j], left.len())
+            } else {
+                width[j] = max(width[j], left.len() + right.len() + 2)
+            }
+        }
+    }
+    let mut output = String::with_capacity(width.iter().sum::<usize>() + width.len() * 3);
+    for i in 0..num_rows {
+        let left = left.get(i).unwrap_or(&EMPTY_ROW);
+        let right = right.get(i).unwrap_or(&EMPTY_ROW);
+        let cols = max(left.len(), right.len());
+        for j in 0..cols {
+            let left = left.get(j).unwrap_or(&EMPTY_VAL);
+            let right = right.get(j).unwrap_or(&EMPTY_VAL);
+            if j != 0 {
+                let _ = write!(&mut output, " | ");
+            }
+            let (value, padding) = if left == right {
+                (left.to_string(), width[j] - left.len())
+            } else {
+                let padding = width[j] - (left.len() + right.len() + 2);
+                let value = format!(
+                    "{}{}{}{}",
+                    "-".magenta(),
+                    left.magenta(),
+                    "+".yellow(),
+                    right.yellow()
+                );
+                (value, padding)
+            };
+            // trick to ensure correct padding, the color characters are counted
+            // if done the normal way.
+            let _ = write!(&mut output, "{:>padding$}{}", "", value, padding = padding);
+        }
+        let _ = writeln!(&mut output);
+    }
+    output
+}
+
+pub enum TestError {
+    PgError(postgres::Error),
+    OutputError(String),
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TestError::PgError(error) => {
+                match error.source().and_then(|e| e.downcast_ref::<DbError>()) {
+                    Some(e) => {
+                        use postgres::error::ErrorPosition::*;
+                        let pos = match e.position() {
+                            Some(Original(pos)) => format!("At character {}", pos),
+                            Some(Internal { position, query }) => {
+                                format!("In internal query `{}` at {}", query, position)
+                            }
+                            None => String::new(),
+                        };
+                        write!(
+                            f,
+                            "{}\n{}\n{}\n{}",
+                            "Postgres Error:".bold().red(),
+                            e,
+                            e.detail().unwrap_or(""),
+                            pos,
+                        )
+                    }
+                    None => write!(f, "{}", error),
+                }
+            }
+            TestError::OutputError(err) => write!(f, "{} {}", "Error:".bold().red(), err),
+        }
+    }
+}
+
+impl From<postgres::Error> for TestError {
+    fn from(error: postgres::Error) -> Self {
+        TestError::PgError(error)
+    }
+}
+
+impl TestError {
+    pub fn annotate_position<'s>(&self, sql: &'s str) -> Cow<'s, str> {
+        match self.location() {
+            None => sql.into(),
+            Some(pos) => format!(
+                "{}{}{}",
+                &sql[..pos as usize],
+                "~>".bright_red(),
+                &sql[pos as usize..],
+            )
+            .into(),
+        }
+    }
+
+    fn location(&self) -> Option<u32> {
+        use postgres::error::ErrorPosition::*;
+        match self {
+            TestError::OutputError(..) => None,
+            TestError::PgError(e) => match e
+                .source()
+                .and_then(|e| e.downcast_ref::<DbError>().and_then(DbError::position))
+            {
+                None => None,
+                Some(Internal { .. }) => None,
+                Some(Original(pos)) => Some(pos.saturating_sub(1)),
+            },
+        }
+    }
+}
+
+struct Deferred<T: FnMut()>(T);
+
+impl<T: FnMut()> Drop for Deferred<T> {
+    fn drop(&mut self) {
+        self.0()
+    }
+}


### PR DESCRIPTION
This PR creates the `sql-doctester` tool; a program that walks a path searching for Markdown files containing SQL code blocks, and runs them to ensure they're correct. We expect to use this to test that our documentation is correct, and to run tests we cannot run through `pgx`.

Still to come is CI integration.