### PR TITLE
Switch to varlena_type!() to construct out custom types

### DIFF
--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -12,14 +12,6 @@ use flat_serialize::*;
 
 use time_weighted_average::tspoint::TSPoint;
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(NormalizedTimeSeries);
-}
-
 // This is included for debug purposes and probably should not leave experimental
 #[pg_extern(schema = "timescale_analytics_experimental")]
 pub fn asap_smooth_raw(
@@ -168,6 +160,14 @@ pg_type! {
 
 
 json_inout_funcs!(NormalizedTimeSeries);
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(NormalizedTimeSeries);
+}
 
 impl<'input> NormalizedTimeSeries<'input> {
     #[allow(dead_code)]

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -13,7 +13,7 @@ use crate::{
     aggregate_utils::in_aggregate_context,
     json_inout_funcs,
     flatten,
-    palloc::Internal, 
+    palloc::Internal,
     pg_type,
     range::*,
 };
@@ -34,18 +34,12 @@ type tstzrange = Datum;
 // so that pgx generates the correct SQL
 mod timescale_analytics_experimental {
     pub(crate) use super::*;
-    extension_sql!(r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
-    "#);
+
+    varlena_type!(CounterSummary);
 }
 
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
-
-
-extension_sql!(r#"
-CREATE TYPE timescale_analytics_experimental.CounterSummary;
-"#);
 
 pg_type! {
     #[derive(Debug, PartialEq)]
@@ -99,18 +93,6 @@ impl<'input> CounterSummary<'input> {
     // }
 }
 
-extension_sql!(r#"
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.counter_summary_in(cstring) RETURNS timescale_analytics_experimental.CounterSummary IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C AS 'MODULE_PATHNAME', 'countersummary_in_wrapper';
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.counter_summary_out(timescale_analytics_experimental.CounterSummary) RETURNS CString IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C AS 'MODULE_PATHNAME', 'countersummary_out_wrapper';
-
-CREATE TYPE timescale_analytics_experimental.CounterSummary (
-    INTERNALLENGTH = variable,
-    INPUT = timescale_analytics_experimental.counter_summary_in,
-    OUTPUT = timescale_analytics_experimental.counter_summary_out,
-    STORAGE = extended
-);
-"#);
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CounterSummaryTransState {
     #[serde(skip)]
@@ -118,8 +100,8 @@ pub struct CounterSummaryTransState {
     #[serde(skip)]
     bounds: Option<I64Range>, // stores bounds until we combine points, after which, the bounds are stored in each summary
     // We have a summary buffer here in order to deal with the fact that when the cmobine function gets called it
-    // must first build up a buffer of InternalMetricSummaries, then sort them, then call the combine function in 
-    // the correct order. 
+    // must first build up a buffer of InternalMetricSummaries, then sort them, then call the combine function in
+    // the correct order.
     summary_buffer: Vec<InternalCounterSummary>,
 }
 
@@ -238,7 +220,7 @@ pub fn counter_agg_summary_trans(
 ) -> Option<Internal<CounterSummaryTransState>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
-            match (state, value) { 
+            match (state, value) {
                 (state, None) => state,
                 (None, Some(value)) => Some(
                     CounterSummaryTransState{point_buffer: vec![], bounds: None, summary_buffer: vec![value.to_internal_counter_summary()]}.into()),
@@ -317,7 +299,7 @@ CREATE AGGREGATE timescale_analytics_experimental.counter_agg( ts timestamptz, v
 );
 "#);
 
-// allow calling counter agg without bounds provided. 
+// allow calling counter agg without bounds provided.
 extension_sql!(r#"
 CREATE AGGREGATE timescale_analytics_experimental.counter_agg( ts timestamptz, value DOUBLE PRECISION )
 (
@@ -503,7 +485,7 @@ fn counter_agg_counter_zero_time(
 
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {
-    
+
     use approx::assert_relative_eq;
     use pgx::*;
     use super::*;
@@ -568,7 +550,7 @@ mod tests {
 
             let stmt = "SELECT extrapolated_rate(counter_agg(ts, val, '[2020-01-01 00:00:00+00, 2020-01-01 00:02:00+00)'), 'prometheus') FROM test";
             assert_relative_eq!(select_one!(client, stmt, f64), 20.0 / 120.0);
-            
+
             let stmt = "INSERT INTO test VALUES('2020-01-01 00:02:00+00', 10.0), ('2020-01-01 00:03:00+00', 20.0), ('2020-01-01 00:04:00+00', 10.0)";
             client.select(stmt, None, None);
 
@@ -610,7 +592,7 @@ mod tests {
     // #[pg_test]
     // fn test_combine_aggregate(){
     //     Spi::execute(|client| {
-            
+
     //     });
     // }
 }

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -30,13 +30,6 @@ use counter_agg::{
 
 #[allow(non_camel_case_types)]
 type tstzrange = Datum;
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(CounterSummary);
-}
 
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
@@ -57,6 +50,14 @@ pg_type! {
 }
 
 json_inout_funcs!(CounterSummary);
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(CounterSummary);
+}
 
 impl<'input> CounterSummary<'input> {
     fn to_internal_counter_summary(&self) -> InternalCounterSummary {

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -23,14 +23,6 @@ use crate::{
 
 use hyperloglog::{HyperLogLog as HLL, HyperLogLogger};
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(Hyperloglog);
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct HyperLogLogTrans {
     logger: HyperLogLogger<Datum, DatumHashBuilder>,
@@ -125,6 +117,14 @@ pg_type! {
         b: u32,
         registers: [u8; (1 as usize) << self.b],
     }
+}
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(Hyperloglog);
 }
 
 json_inout_funcs!(HyperLogLog);

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -14,14 +14,9 @@ use flat_serialize::*;
 // so that pgx generates the correct SQL
 mod timescale_analytics_experimental {
     pub(crate) use super::*;
-    extension_sql!(r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
-    "#);
-}
 
-extension_sql!(r#"
-CREATE TYPE timescale_analytics_experimental.SortedTimeseries;
-"#);
+    varlena_type!(SortedTimeseries);
+}
 
 pg_type! {
     #[derive(Debug)]
@@ -32,25 +27,6 @@ pg_type! {
 }
 
 json_inout_funcs!(SortedTimeseries);
-
-extension_sql!(r#"
-CREATE OR REPLACE FUNCTION
-    timescale_analytics_experimental.SortedTimeseries_in(cstring)
-RETURNS timescale_analytics_experimental.SortedTimeseries
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'sortedtimeseries_in_wrapper';
-CREATE OR REPLACE FUNCTION
-    timescale_analytics_experimental.SortedTimeseries_out(timescale_analytics_experimental.SortedTimeseries)
-RETURNS CString
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'sortedtimeseries_out_wrapper';
-CREATE TYPE timescale_analytics_experimental.SortedTimeseries (
-    INTERNALLENGTH = variable,
-    INPUT = timescale_analytics_experimental.SortedTimeseries_in,
-    OUTPUT = timescale_analytics_experimental.SortedTimeseries_out,
-    STORAGE = extended
-);
-"#);
 
 #[pg_extern(name = "unnest_series", schema = "timescale_analytics_experimental")]
 pub fn unnest_sorted_series(

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -10,14 +10,6 @@ use time_weighted_average::tspoint::TSPoint;
 
 use flat_serialize::*;
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(SortedTimeseries);
-}
-
 pg_type! {
     #[derive(Debug)]
     struct SortedTimeseries {
@@ -27,6 +19,14 @@ pg_type! {
 }
 
 json_inout_funcs!(SortedTimeseries);
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(SortedTimeseries);
+}
 
 #[pg_extern(name = "unnest_series", schema = "timescale_analytics_experimental")]
 pub fn unnest_sorted_series(

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -19,14 +19,6 @@ use tdigest::{
     Centroid,
 };
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(TDigest);
-}
-
 // Intermediate state kept in postgres.  This is a tdigest object paired
 // with a vector of values that still need to be inserted.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -155,6 +147,14 @@ pg_type! {
 }
 
 json_inout_funcs!(TDigest);
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(TDigest);
+}
 
 impl<'input> TDigest<'input> {
     fn to_internal_tdigest(&self) -> InternalTDigest {

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -23,9 +23,8 @@ use tdigest::{
 // so that pgx generates the correct SQL
 mod timescale_analytics_experimental {
     pub(crate) use super::*;
-    extension_sql!(r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
-    "#);
+
+    varlena_type!(TDigest);
 }
 
 // Intermediate state kept in postgres.  This is a tdigest object paired
@@ -141,10 +140,6 @@ pub fn tdigest_deserialize(
     crate::do_deserialize!(bytes, TDigestTransState)
 }
 
-extension_sql!(r#"
-CREATE TYPE timescale_analytics_experimental.TDigest;
-"#);
-
 // PG object for the digest.
 pg_type! {
     #[derive(Debug)]
@@ -217,25 +212,6 @@ fn tdigest_final(
 
 
 extension_sql!(r#"
-CREATE OR REPLACE FUNCTION
-    timescale_analytics_experimental.TDigest_in(cstring)
-RETURNS timescale_analytics_experimental.TDigest
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'tdigest_in_wrapper';
-
-CREATE OR REPLACE FUNCTION
-    timescale_analytics_experimental.TDigest_out(timescale_analytics_experimental.TDigest)
-RETURNS CString
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'tdigest_out_wrapper';
-
-CREATE TYPE timescale_analytics_experimental.TDigest (
-    INTERNALLENGTH = variable,
-    INPUT = timescale_analytics_experimental.TDigest_in,
-    OUTPUT = timescale_analytics_experimental.TDigest_out,
-    STORAGE = extended
-);
-
 CREATE AGGREGATE timescale_analytics_experimental.tdigest(size int, value DOUBLE PRECISION)
 (
     sfunc = timescale_analytics_experimental.tdigest_trans,

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -14,14 +14,6 @@ use time_weighted_average::{
     TimeWeightSummary as TimeWeightSummaryInternal,
 };
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(TimeWeightSummary);
-}
-
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
 
@@ -36,6 +28,14 @@ pg_type! {
 }
 
 json_inout_funcs!(TimeWeightSummary);
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(TimeWeightSummary);
+}
 
 impl<'input> TimeWeightSummary<'input> {
     #[allow(non_snake_case)]

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -18,21 +18,12 @@ use time_weighted_average::{
 // so that pgx generates the correct SQL
 mod timescale_analytics_experimental {
     pub(crate) use super::*;
-    extension_sql!(
-        r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
-    "#
-    );
+
+    varlena_type!(TimeWeightSummary);
 }
 
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
-
-extension_sql!(
-    r#"
-CREATE TYPE timescale_analytics_experimental.TimeWeightSummary;
-"#
-);
 
 pg_type! {
     #[derive(Debug)]
@@ -57,27 +48,6 @@ impl<'input> TimeWeightSummary<'input> {
         }
     }
 }
-
-extension_sql!(
-    r#"
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.TimeWeightSummary_in(cstring)
-RETURNS timescale_analytics_experimental.TimeWeightSummary
-IMMUTABLE STRICT PARALLEL SAFE
-LANGUAGE C AS 'MODULE_PATHNAME', 'timeweightsummary_in_wrapper'; -- This is case sensitive and is generated lowercase
-
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.TimeWeightSummary_out(timescale_analytics_experimental.TimeWeightSummary)
-RETURNS CString
-IMMUTABLE STRICT PARALLEL SAFE
-LANGUAGE C AS 'MODULE_PATHNAME', 'timeweightsummary_out_wrapper'; -- This is case sensitive and is generated lowercase
-
-CREATE TYPE timescale_analytics_experimental.TimeWeightSummary (
-    INTERNALLENGTH = variable,
-    INPUT = timescale_analytics_experimental.TimeWeightSummary_in,
-    OUTPUT = timescale_analytics_experimental.TimeWeightSummary_out,
-    STORAGE = extended
-);
-"#
-);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TimeWeightTransState {

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -23,9 +23,8 @@ use crate::{
 // so that pgx generates the correct SQL
 mod timescale_analytics_experimental {
     pub(crate) use super::*;
-    extension_sql!(r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
-    "#);
+
+    varlena_type!(UddSketch);
 }
 
 #[allow(non_camel_case_types)]
@@ -98,10 +97,6 @@ pub fn uddsketch_deserialize(
     crate::do_deserialize!(bytes, UddSketchInternal)
 }
 
-extension_sql!(r#"
-CREATE TYPE timescale_analytics_experimental.UddSketch;
-"#);
-
 // PG object for the sketch.
 pg_type! {
     struct UddSketch {
@@ -165,23 +160,6 @@ fn uddsketch_final(
 }
 
 extension_sql!(r#"
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.UddSketch_in(cstring)
-RETURNS timescale_analytics_experimental.UddSketch
-IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'uddsketch_in_wrapper';
-
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.UddSketch_out(
-    timescale_analytics_experimental.UddSketch
-) RETURNS CString IMMUTABLE STRICT PARALLEL SAFE LANGUAGE C
-AS 'MODULE_PATHNAME', 'uddsketch_out_wrapper';
-
-CREATE TYPE timescale_analytics_experimental.UddSketch (
-    INTERNALLENGTH = variable,
-    INPUT = timescale_analytics_experimental.UddSketch_in,
-    OUTPUT = timescale_analytics_experimental.UddSketch_out,
-    STORAGE = extended
-);
-
 CREATE AGGREGATE timescale_analytics_experimental.uddsketch(
     size int, max_error DOUBLE PRECISION, value DOUBLE PRECISION
 ) (

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -19,14 +19,6 @@ use crate::{
     palloc::Internal, pg_type
 };
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
-// so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
-    pub(crate) use super::*;
-
-    varlena_type!(UddSketch);
-}
-
 #[allow(non_camel_case_types)]
 type int = u32;
 
@@ -109,6 +101,14 @@ pg_type! {
         keys: [uddsketch::SketchHashKey; self.num_buckets],
         counts: [u64; self.num_buckets],
     }
+}
+
+// hack to allow us to qualify names with "timescale_analytics_experimental"
+// so that pgx generates the correct SQL
+mod timescale_analytics_experimental {
+    pub(crate) use super::*;
+
+    varlena_type!(UddSketch);
 }
 
 json_inout_funcs!(UddSketch);


### PR DESCRIPTION
Here's something for you guys to looks at. This commit switches over our type construction to a new `varlena_type!()` pseudo-macro in order to reduce the boilerplate needed to construct our custom types. This pseudo-macro causes our fork of `cargo-pgx` to generate the same SQL we're writing by hand now. Currently it needs to be put in the same hacky `timescale_analytics_experimental` pseudo-`mod` we use to make sure the types are namespaced correctly, not sure yet if I can fix that.

So what do you think, is this better or worse than what we had before? (If it's better, I'll probably move the `timescale_analytics_experimental` pseudo mod down to the type-definition in each file; I think it'll read better there)