### PR TITLE
Make the anchor links work properly in our docs

### DIFF
--- a/extension/docs/README.md
+++ b/extension/docs/README.md
@@ -2,7 +2,7 @@
 ---
 The Timescale Analytics project contains a number of utilities for working with time-series data.  This documentation is further broken down by utility or feature in the list [below](#analytics-features).
 
-## A note on tags [](tag-notes)
+## A note on tags <a id="tag-notes"></a>
 Functionality within the Timescale Analytics repository is intended to be introduced in varying stages of completeness.  To clarify which releases a given feature or function can be found in, the following tags are used:
  - **Experimental** - Denotes functionality that is still under very active development and may have poor performance, not handle corner cases or errors, etc.  Experimental APIs will change across releases, and extension-update will drop database objects that depend on experimental features. Do not use them unless you're willing ot deal with the object you've created (the view, table, continuous aggregates, function, etc.) being dropped on update. This is particularly important for Forge users, as automatic extension updates WILL DELETE database objects. Experimental features and functions can be found exclusively in the `timescale_analytics_experimental` schema.
  - **Stable** ***release id*** - Functionality in this state should be correct and performant.  Stable APIs will be found in our releases and should not be broken in future releases.  Note that this tag will also be accompanied with the version in which the feature was originally released, such as: Feature Foo<sup><mark>stable-1.2</mark></sup>.
@@ -10,7 +10,7 @@ Functionality within the Timescale Analytics repository is intended to be introd
 
 Note that tags can be applied at either a feature or function scope.  The function tag takes precedence, but defaults to the feature scope if not present.  For example, if we have a feature `Foo` which is tagged `stable`, we would assume that an untagged function `FooCount` within that feature would be present in the current beta release.  However, if function `FooSum` were explicitly tagged `experimental` then we would only expect to find it in the nightly build.
 
-## Analytics features [](analytics-features)
+## Analytics features <a id="analytics-features"></a>
 
 The following links lead to pages for the different features in the Timescale Analytics repository.
 

--- a/extension/docs/asap.md
+++ b/extension/docs/asap.md
@@ -5,17 +5,17 @@
 > [Example](#asap-example)<br>
 > [API](#asap-api)
 
-## Description [](asap-description)
+## Description <a id="asap-description"></a>
 
 The [ASAP smoothing alogrithm](https://arxiv.org/pdf/1703.00983.pdf) is designed create human readable graphs which preserve the rough shape and larger trends of the input data while minimizing the local variance between points.  Timescale analytics provides an implementation of this which will take `(timestamp, value)` pairs, normalize them to the target interval, and return the ASAP smoothed values.
 
-## Details [](asap-details)
+## Details <a id="asap-details"></a>
 
 Timescale's ASAP smoothing is implemented as a PostgresQL aggregate over a series of timestamps and values, with an additional target resolution used to control the output size.  The implementation will take the incoming data and attempt to bucket the points into even sized buckets such the number of buckets approximates the target resolution and each bucket contains a similar number of points (if necessary, gaps will be filled by interpolating the buckets on either side at this point).  It will then attempt to identify good candidate intervals for smoothing the data (using the Wiener-Khinchin theorem to find periods of high autocorrelation), and then choose the candidate that produces the smoothest graph while having the same degree of outlier values.
 
 The output of the postgres aggregate is a timescale timeseries object describing the start and step interval times and listing the values.  This can be passed to our `unnest_series` API to produce a table of time, value points.  The aggreates are also currently not partializeable or combinable.
 
-## Usage Example [](asap-example)
+## Usage Example <a id="asap-example"></a>
 
 In this example we're going to examine about 250 years of monthly temperature readings from England (raw data can be found [here](http://futuredata.stanford.edu/asap/Temp.csv), though timestamps need to have a day added to be readable by PostgresQL).  
 
@@ -75,11 +75,11 @@ Note the use of the `unnest_series` here to unpack the results of the `asap_smoo
 ![Smoothed data](images/ASAP_smoothed.png)
 
 
-## Command List (A-Z) [](asap-api)
+## Command List (A-Z) <a id="asap-api"></a>
 > - [asap_smooth](#asap_smooth)
 
 ---
-## **asap_smooth** [](asap_smooth)
+## **asap_smooth** <a id="asap_smooth"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.asap_smooth(
     ts TIMESTAMPTZ,
@@ -90,7 +90,7 @@ timescale_analytics_experimental.asap_smooth(
 
 This normalize time, value pairs over a given interval and return a smoothed representation of those points.
 
-### Required Arguments [](asap-required-arguments)
+### Required Arguments <a id="asap-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `ts` | `TIMESTAMPTZ` | Column of timestamps corresponding to the values to aggregate |
@@ -105,7 +105,7 @@ This normalize time, value pairs over a given interval and return a smoothed rep
 | `normalizedtimeseries` | `NormalizedTimeSeries` | A object representing a series of values occurring at set intervals from a starting time.  It can be unpacked via `unnest_series` |
 <br>
 
-### Sample Usages [](asap-examples)
+### Sample Usages <a id="asap-examples"></a>
 For this examples assume we have a table 'metrics' with columns 'date' and 'reading' which contains some interesting measurment we've accumulated over a large interval.  The following example would take that data and give us a smoothed representation of approximately 10 points which would still show any anomolous readings:
 
 <div hidden>

--- a/extension/docs/hyperloglog.md
+++ b/extension/docs/hyperloglog.md
@@ -4,21 +4,21 @@
 > [Details](#hyperloglog-details)<br>
 > [API](#hyperloglog-api)
 
-## Description [](hyperloglog-description)
+## Description <a id="hyperloglog-description"></a>
 
 Timescale analytics provides an implementation of the [Hyperloglog estimator](https://en.wikipedia.org/wiki/HyperLogLog) for `COUNT DISTINCT` approximations of any type that has a hash function.
 
-## Details [](hyperloglog-details)
+## Details <a id="hyperloglog-details"></a>
 
 Timescale's HyperLogLog is implemented as an aggregate function in PostgreSQL.  They do not support moving-aggregate mode, and are not ordered-set aggregates.  It is restricted to values that have an extended hash function.  They are partializable and are good candidates for [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
 
-## Command List (A-Z) [](hyperloglog-api)
+## Command List (A-Z) <a id="hyperloglog-api"></a>
 > - [hyperloglog](#hyperloglog)
 > - [hyperloglog_count](#hyperloglog_count)
 
 ---
-## **hyperloglog** [](hyperloglog)
+## **hyperloglog** <a id="hyperloglog"></a>
 ```SQL,ignore
 timescale_analytics_experimental.hyperloglog(
     size INTEGER,
@@ -29,7 +29,7 @@ timescale_analytics_experimental.hyperloglog(
 
 This will construct and return a Hyperloglog with at least the specified number of buckets over the given values.
 
-### Required Arguments [](hyperloglog-required-arguments)
+### Required Arguments <a id="hyperloglog-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `buckets` | `INTEGER` | Number of buckets in the digest. Will be rounded up to the next power of 2, must be between 16 and 2^18. Increasing this will usually provide more accurate at the expense of more storage. |
@@ -43,7 +43,7 @@ This will construct and return a Hyperloglog with at least the specified number 
 | `hyperloglog` | `Hyperloglog` | A hyperloglog object which may be passed to other hyperloglog APIs. |
 <br>
 
-### Sample Usages [](hyperloglog-examples)
+### Sample Usages <a id="hyperloglog-examples"></a>
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
 ```SQL ,ignore
@@ -58,7 +58,7 @@ CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, da
 
 ---
 
-## **hyperloglog_count** [](hyperloglog_count)
+## **hyperloglog_count** <a id="hyperloglog_count"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
@@ -66,7 +66,7 @@ timescale_analytics_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETU
 
 Get the number of distinct values from a hyperloglog.
 
-### Required Arguments [](hyperloglog_count-required-arguments)
+### Required Arguments <a id="hyperloglog_count-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `hyperloglog` | `Hyperloglog` | The hyperloglog to extract the count from. |
@@ -79,7 +79,7 @@ Get the number of distinct values from a hyperloglog.
 | `hyperloglog_count` | `BIGINT` | The number of distinct elements counted by the hyperloglog. |
 <br>
 
-### Sample Usages [](hyperloglog_count-examples)
+### Sample Usages <a id="hyperloglog_count-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.hyperloglog_count(timescale_analytics_experimental.hyperloglog(64, data))

--- a/extension/docs/lttb.md
+++ b/extension/docs/lttb.md
@@ -4,7 +4,7 @@
 > [Example](#example)<br>
 > [API](#api)
 
-## Description [](description)
+## Description <a id="description"></a>
 
 [Largest Triangle Three Buckets](https://github.com/sveinn-steinarsson/flot-downsample)
 is a downsampling method that tries to retain visual similarity between the
@@ -13,7 +13,7 @@ implementation of this which takes `(timestamp, value)` pairs, sorts them if
 needed, and downsamples them.
 
 
-## Usage Example [](details)
+## Usage Example <a id="details"></a>
 
 In this example we're going to examine downsampling a 101 point cosine wave
 generated like so
@@ -150,11 +150,11 @@ FROM timescale_analytics_experimental.unnest_series((
 
 ![Raw data](images/lttb_8.png)
 
-## Command List (A-Z) [](api)
+## Command List (A-Z) <a id="api"></a>
 > - [lttb](#lttb)
 
 ---
-## **lttb** [](lttb)
+## **lttb** <a id="lttb"></a>
 ```SQL,ignore
 timescale_analytics_experimental.lttb(
     time TIMESTAMPTZ,
@@ -167,7 +167,7 @@ This will construct and return a sorted timeseries with at most `resolution`
 points. `timescale_analytics_experimental.unnest_series(...)` can be used to
 extract the `(time, value)` pairs from this series
 
-### Required Arguments [](lttb-required-arguments)
+### Required Arguments <a id="lttb-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `time` | `TIMESTAMPTZ` | Time (x) value for the data point. |
@@ -175,7 +175,7 @@ extract the `(time, value)` pairs from this series
 | `resolution` | `INTEGER` | Number of points the output should have. |
 <br>
 
-### Sample Usage [](lttb-examples)
+### Sample Usage <a id="lttb-examples"></a>
 
 ```SQL
 SELECT time, value

--- a/extension/docs/tdigest.md
+++ b/extension/docs/tdigest.md
@@ -5,15 +5,15 @@
 > [Example](#tdigest-example)<br>
 > [API](#tdigest-api)
 
-## Description [](tdigest-description)
+## Description <a id="tdigest-description"></a>
 
 Timescale analytics provides an implementation of the [t-digest data structure](https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf) for quantile approximations.  A t-digest is a space efficient aggregation which provides increased resolution at the edges of the distribution.  This allows for more accurate estimates of extreme quantiles than traditional methods.
 
-## Details [](tdigest-details)
+## Details <a id="tdigest-details"></a>
 
 Timescale's t-digest is implemented as an aggregate function in PostgreSQL.  They do not support moving-aggregate mode, and are not ordered-set aggregates.  Presently they are restricted to float values, but the goal is to make them polymorphic.  They are partializable and are good candidates for [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
-## Usage Example [](tdigest-example)
+## Usage Example <a id="tdigest-example"></a>
 
 For this example we're going to start with a table containing some NOAA weather data for a few weather stations across the US over the past 20 years.
 
@@ -90,7 +90,7 @@ FROM high_temp;
 (4 rows)
 ```
 
-## Command List (A-Z) [](tdigest-api)
+## Command List (A-Z) <a id="tdigest-api"></a>
 > - [tdigest](#tdigest)
 > - [tdigest_count](#tdigest_count)
 > - [tdigest_max](#tdigest_max)
@@ -102,7 +102,7 @@ FROM high_temp;
 
 
 ---
-## **tdigest** [](tdigest)
+## **tdigest** <a id="tdigest"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.tdigest(
     buckets INTEGER,
@@ -112,7 +112,7 @@ timescale_analytics_experimental.tdigest(
 
 This will construct and return a TDigest with the specified number of buckets over the given values.
 
-### Required Arguments [](tdigest-required-arguments)
+### Required Arguments <a id="tdigest-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `buckets` | `INTEGER` | Number of buckets in the digest.  Increasing this will provide more accurate quantile estimates, but will require more memory.|
@@ -126,7 +126,7 @@ This will construct and return a TDigest with the specified number of buckets ov
 | `tdigest` | `TDigest` | A t-digest object which may be passed to other t-digest APIs. |
 <br>
 
-### Sample Usages [](tdigest-examples)
+### Sample Usages <a id="tdigest-examples"></a>
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
 ```SQL ,ignore
@@ -143,7 +143,7 @@ CREATE VIEW digest AS
 
 ---
 
-## **tdigest_min** [](tdigest_min)
+## **tdigest_min** <a id="tdigest_min"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.get_min(digest TDigest) RETURNS DOUBLE PRECISION
@@ -151,7 +151,7 @@ timescale_analytics_experimental.get_min(digest TDigest) RETURNS DOUBLE PRECISIO
 
 Get the minimum value from a t-digest.
 
-### Required Arguments [](tdigest_min-required-arguments)
+### Required Arguments <a id="tdigest_min-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` | The digest to extract the min value from. |
@@ -164,7 +164,7 @@ Get the minimum value from a t-digest.
 | `tdigest_min` | `DOUBLE PRECISION` | The minimum value entered into the t-digest. |
 <br>
 
-### Sample Usages [](tdigest-min-examples)
+### Sample Usages <a id="tdigest-min-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.get_min(timescale_analytics_experimental.tdigest(100, data))
@@ -176,7 +176,7 @@ FROM generate_series(1, 100) data;
            1
 ```
 ---
-## **tdigest_max** [](tdigest_max)
+## **tdigest_max** <a id="tdigest_max"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.get_max(digest TDigest) RETURNS DOUBLE PRECISION
@@ -184,7 +184,7 @@ timescale_analytics_experimental.get_max(digest TDigest) RETURNS DOUBLE PRECISIO
 
 Get the maximum value from a t-digest.
 
-### Required Arguments [](tdigest_max-required-arguments)
+### Required Arguments <a id="tdigest_max-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` | The digest to extract the max value from. |
@@ -196,7 +196,7 @@ Get the maximum value from a t-digest.
 | `max` | `DOUBLE PRECISION` | The maximum value entered into the t-digest. |
 <br>
 
-### Sample Usage [](tdigest_max-examples)
+### Sample Usage <a id="tdigest_max-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.get_max(timescale_analytics_experimental.tdigest(100, data))
@@ -208,7 +208,7 @@ FROM generate_series(1, 100) data;
      100
 ```
 ---
-## **tdigest_count** [](tdigest_count)
+## **tdigest_count** <a id="tdigest_count"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.get_count(digest TDigest) RETURNS DOUBLE PRECISION
@@ -216,7 +216,7 @@ timescale_analytics_experimental.get_count(digest TDigest) RETURNS DOUBLE PRECIS
 
 Get the number of values contained in a t-digest.
 
-### Required Arguments [](tdigest_count-required-arguments)
+### Required Arguments <a id="tdigest_count-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` | The digest to extract the number of values from. |
@@ -228,7 +228,7 @@ Get the number of values contained in a t-digest.
 | `count` | `DOUBLE PRECISION` | The number of values entered into the t-digest. |
 <br>
 
-### Sample Usage [](tdigest_count-examples)
+### Sample Usage <a id="tdigest_count-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.get_count(timescale_analytics_experimental.tdigest(100, data))
@@ -241,7 +241,7 @@ FROM generate_series(1, 100) data;
 ```
 
 ---
-## **tdigest_mean** [](tdigest_mean)
+## **tdigest_mean** <a id="tdigest_mean"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.mean(digest TDigest) RETURNS DOUBLE PRECISION
@@ -249,7 +249,7 @@ timescale_analytics_experimental.mean(digest TDigest) RETURNS DOUBLE PRECISION
 
 Get the average of all the values contained in a t-digest.
 
-### Required Arguments [](tdigest_mean-required-arguments)
+### Required Arguments <a id="tdigest_mean-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` |  The digest to extract the mean value from. |
@@ -261,7 +261,7 @@ Get the average of all the values contained in a t-digest.
 | `mean` | `DOUBLE PRECISION` | The average of the values entered into the t-digest. |
 <br>
 
-### Sample Usage [](tdigest_mean-examples)
+### Sample Usage <a id="tdigest_mean-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.mean(timescale_analytics_experimental.tdigest(100, data))
@@ -274,7 +274,7 @@ FROM generate_series(1, 100) data;
 ```
 
 ---
-## **tdigest_sum** [](tdigest_sum)
+## **tdigest_sum** <a id="tdigest_sum"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.sum(digest TDigest) RETURNS DOUBLE PRECISION
@@ -282,7 +282,7 @@ timescale_analytics_experimental.sum(digest TDigest) RETURNS DOUBLE PRECISION
 
 Get the sum of all the values in a t-digest
 
-### Required Arguments [](tdigest_sum-required-arguments)
+### Required Arguments <a id="tdigest_sum-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` |  The digest to compute the sum on. |
@@ -294,7 +294,7 @@ Get the sum of all the values in a t-digest
 | `sum` | `DOUBLE PRECISION` | The sum of the values entered into the t-digest. |
 <br>
 
-### Sample Usage [](tdigest_sum-examples)
+### Sample Usage <a id="tdigest_sum-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.sum(timescale_analytics_experimental.tdigest(100, data))
@@ -307,7 +307,7 @@ FROM generate_series(1, 100) data;
 ```
 
 ---
-## **tdigest_quantile** [](tdigest_quantile)
+## **tdigest_quantile** <a id="tdigest_quantile"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.quantile(
@@ -318,7 +318,7 @@ timescale_analytics_experimental.quantile(
 
 Get the approximate value at a quantile from a t-digest
 
-### Required Arguments [](tdigest_quantile-required-arguments)
+### Required Arguments <a id="tdigest_quantile-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` | The digest to compute the quantile on. |
@@ -331,7 +331,7 @@ Get the approximate value at a quantile from a t-digest
 | `quantile` | `DOUBLE PRECISION` | The estimated value at the requested quantile. |
 <br>
 
-### Sample Usage [](tdigest_quantile-examples)
+### Sample Usage <a id="tdigest_quantile-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.quantile(timescale_analytics_experimental.tdigest(100, data), 0.90)
@@ -344,7 +344,7 @@ FROM generate_series(1, 100) data;
 ```
 
 ---
-## **tdigest_quantile_at_value** [](tdigest_quantile_at_value)
+## **tdigest_quantile_at_value** <a id="tdigest_quantile_at_value"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.quantile_at_value(
@@ -355,7 +355,7 @@ timescale_analytics_experimental.quantile_at_value(
 
 Estimate what quantile a given value would be located at in a t-digest.
 
-### Required Arguments [](tdigest_quantile_at_value-required-arguments)
+### Required Arguments <a id="tdigest_quantile_at_value-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `digest` | `TDigest` | The digest to compute the quantile on. |
@@ -368,7 +368,7 @@ Estimate what quantile a given value would be located at in a t-digest.
 | `quantile_at_value` | `DOUBLE PRECISION` | The estimated quantile associated with the provided value. |
 <br>
 
-### Sample Usage [](tdigest_quantile_at_value-examples)
+### Sample Usage <a id="tdigest_quantile_at_value-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.quantile_at_value(timescale_analytics_experimental.tdigest(100, data), 90)

--- a/extension/docs/time_weighted_average.md
+++ b/extension/docs/time_weighted_average.md
@@ -7,7 +7,7 @@
 > [Interpolation Methods Details](#time-weight-methods)<br>
 
 
-## Description [](time-weighted-average-description)
+## Description <a id="time-weighted-average-description"></a>
 
 Time weighted averages are commonly used in cases where a time series is not evenly sampled, so a traditional average will give misleading results. Consider a voltage sensor that sends readings once every 5 minutes or whenever the value changes by more than 1 V from the previous reading. If the results are generally stable, but with some quick moving transients, a simple average over all of the points will tend to over-weight the transients instead of the stable readings. A time weighted average weights each value by the duration over which it occured based on the points around it and produces correct results for unevenly spaced series.
 
@@ -16,7 +16,7 @@ Timescale Analytics' time weighted average is implemented as an aggregate which 
 Additionally, [see the notes on parallelism and ordering](#time-weight-ordering) for a deeper dive into considerations for use with parallelism and some discussion of the internal data structures.
 
 ---
-## Example Usage [](time-weighted-average-examples)
+## Example Usage <a id="time-weighted-average-examples"></a>
 For these examples we'll assume a table `foo` defined as follows:
 ```SQL ,ignore
 CREATE TABLE foo (
@@ -104,13 +104,13 @@ GROUP BY measure_id
 ```
 ---
 
-## Command List (A-Z) [](time-weighted-average-api)
+## Command List (A-Z) <a id="time-weighted-average-api"></a>
 > - [time_weight() (point form)](#time_weight_point)
 > - [time_weight() (summary form)](#time-weight-summary)
 > - [average()](#time-weight-average)
 
 ---
-## **time_weight() (point form)** [](time_weight_point)
+## **time_weight() (point form)** <a id="time_weight_point"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.time_weight(
     method TEXT¹,
@@ -122,7 +122,7 @@ timescale_analytics_experimental.time_weight(
 
 An aggregate that produces a `TimeWeightSummary` from timestamps and associated values.
 
-### Required Arguments² [](time-weight-point-required-arguments)
+### Required Arguments² <a id="time-weight-point-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `method` | `TEXT` | The weighting method we should use, options are 'linear' or 'LOCF', not case sensitive |
@@ -155,7 +155,7 @@ SELECT
 FROM t;
 ```
 
-## **time_weight() (summary form)** [](time-weight-summary)
+## **time_weight() (summary form)** <a id="time-weight-summary"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.time_weight(
     tws TimeWeightSummary
@@ -164,7 +164,7 @@ timescale_analytics_experimental.time_weight(
 
 An aggregate to compute a combined `TimeWeightSummary` from a series of non-overlapping `TimeWeightSummaries`. Non-disjoint `TimeWeightSummaries` will cause errors. See [Notes on Parallelism and Ordering](#time-weight-ordering) for more information.
 
-### Required Arguments² [](time-weight-summary-required-arguments)
+### Required Arguments² <a id="time-weight-summary-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `tws` | `TimeWeightSummary` | The input TimeWeightSummary from a previous `time_weight` (point form) call, often from a [continuous aggregate](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates)|
@@ -196,7 +196,7 @@ SELECT
 FROM t;
 ```
 
-## **average()** [](time-weight-average)
+## **average()** <a id="time-weight-average"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.average(
     tws TimeWeightSummary
@@ -205,7 +205,7 @@ timescale_analytics_experimental.average(
 
 A function to compute a time weighted average from a `TimeWeightSummary`.
 
-### Required Arguments [](time-weight-summary-required-arguments)
+### Required Arguments <a id="time-weight-summary-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `tws` | `TimeWeightSummary` | The input TimeWeightSummary from a `time_weight` call.|
@@ -232,7 +232,7 @@ FROM (
 ) t
 ```
 ---
-## Notes on Parallelism and Ordering [](time-weight-ordering)
+## Notes on Parallelism and Ordering <a id="time-weight-ordering"></a>
 
 The time weighted average calculations we perform require a strict ordering of inputs and therefore the calculations are not parallelizable in the strict Postgres sense. This is because when Postgres does parallelism it hands out rows randomly, basically as it sees them to workers. However, if your parallelism can guarantee disjoint (in time) sets of rows, the algorithm can be parallelized, just so long as within some time range, all rows go to the same worker. This is the case for both [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates) and for [distributed hypertables](https://docs.timescale.com/latest/using-timescaledb/distributed-hypertables) (as long as the partitioning keys are in the group by, though the aggregate itself doesn't horribly make sense otherwise).
 
@@ -271,7 +271,7 @@ GROUP BY measure_id;
 Moving aggregate mode is not supported by `time_weight` and its use as a window function may be quite inefficient.
 
 ---
-## Interpolation Methods Details [](time-weight-methods)
+## Interpolation Methods Details <a id="time-weight-methods"></a>
 
 Discrete time values don't always allow for an obvious calculation of the time weighted average. In order to calculate a time weighted average we need to choose how to weight each value. The two methods we currently use are last observation carried forward (LOCF) and linear interpolation.
 

--- a/extension/docs/uddsketch.md
+++ b/extension/docs/uddsketch.md
@@ -5,7 +5,7 @@
 > [Example](#uddsketch-example)<br>
 > [API](#uddsketch-api)
 
-## Description [](uddsketch-description)
+## Description <a id="uddsketch-description"></a>
 
 [UddSketch](https://arxiv.org/pdf/2004.08604.pdf) is a specialization of the [DDSketch](https://arxiv.org/pdf/1908.10693.pdf) data structure.  It follows the same approach of breaking the data range into a series of logarithmically sized buckets such that it can guarantee a maximum relative error for any quantile estimate as long as it knows which bucket that quantile falls in.
 
@@ -13,11 +13,11 @@ Where UddSketch differs from DDSketch in its behavior when the number of buckets
 
 As an example, assume both sketches were trying to capture an large set of values to be able to estimate quantiles with 1% relative error but were given too few buckets to do so.  The DDSketch implementation would still guarantee 1% relative error, but may only be able to provides estimates in the range (0.05, 0.95).  The UddSketch implementation however, might end up only able to guarantee 2% relative error, but would still be able to estimate all quantiles at that error.
 
-## Details [](uddsketch-details)
+## Details <a id="uddsketch-details"></a>
 
 Timescale's UddSketch implementation is provided as an aggregate function in PostgreSQL.  It does not support moving-aggregate mode, and is not a ordered-set aggregate.  It currently only works with `DOUBLE PRECISION` types, but we're intending to relax this constraint as needed.  UddSketches are partializable and are good candidates for [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
-## Usage Example [](uddsketch-example)
+## Usage Example <a id="uddsketch-example"></a>
 
 For this example we're going to start with a table containing some NOAA weather data for a few weather stations across the US over the past 20 years.
 
@@ -111,7 +111,7 @@ FROM daily_rain;
 (4 rows)
 ```
 
-## Command List (A-Z) [](uddsketch-api)
+## Command List (A-Z) <a id="uddsketch-api"></a>
 > - [uddsketch](#uddsketch)
 > - [uddsketch_count](#uddsketch_count)
 > - [uddsketch_error](#uddsketch_error)
@@ -121,7 +121,7 @@ FROM daily_rain;
 
 
 ---
-## **uddsketch** [](uddsketch)
+## **uddsketch** <a id="uddsketch"></a>
 ```SQL ,ignore
 timescale_analytics_experimental.uddsketch(
     size INTEGER,
@@ -132,7 +132,7 @@ timescale_analytics_experimental.uddsketch(
 
 This will construct and return a new UddSketch with at most `size` buckets.  The maximum relative error of the UddSketch will be bounded by `max_error` unless it is impossible to do so while with the bucket bound.  If the sketch has had to combine buckets, the new error can be found with the [uddsketch_error](#uddsketch_error) command.
 
-### Required Arguments [](uddsketch-required-arguments)
+### Required Arguments <a id="uddsketch-required-arguments"></a>
 |Name| Type |Description|
 |---|---|---|
 | `size` | `INTEGER` | Maximum number of buckets in the sketch.  Providing a larger value here will make it more likely that the aggregate will able to maintain the desired error, though will potentially increase the memory usage. |
@@ -147,7 +147,7 @@ This will construct and return a new UddSketch with at most `size` buckets.  The
 | `uddsketch` | `UddSketch` | A UddSketch object which may be passed to other UddSketch APIs. |
 <br>
 
-### Sample Usages [](uddsketch-examples)
+### Sample Usages <a id="uddsketch-examples"></a>
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a sketch over that column
 
 ```SQL ,ignore
@@ -163,7 +163,7 @@ CREATE VIEW sketch AS
 ```
 
 ---
-## **uddsketch_count** [](uddsketch_count)
+## **uddsketch_count** <a id="uddsketch_count"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.get_count(sketch UddSketch) RETURNS DOUBLE PRECISION
@@ -171,7 +171,7 @@ timescale_analytics_experimental.get_count(sketch UddSketch) RETURNS DOUBLE PREC
 
 Get the number of values contained in a UddSketch.
 
-### Required Arguments [](uddsketch_count-required-arguments)
+### Required Arguments <a id="uddsketch_count-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `sketch` | `UddSketch` | The sketch to extract the number of values from. |
@@ -183,7 +183,7 @@ Get the number of values contained in a UddSketch.
 | `uddsketch_count` | `DOUBLE PRECISION` | The number of values entered into the UddSketch. |
 <br>
 
-### Sample Usage [](uddsketch_count-examples)
+### Sample Usage <a id="uddsketch_count-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.get_count(
@@ -198,7 +198,7 @@ SELECT timescale_analytics_experimental.get_count(
 
 ---
 
-## **uddsketch_error** [](uddsketch_error)
+## **uddsketch_error** <a id="uddsketch_error"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.error(sketch UddSketch) RETURNS DOUBLE PRECISION
@@ -206,7 +206,7 @@ timescale_analytics_experimental.error(sketch UddSketch) RETURNS DOUBLE PRECISIO
 
 This returns the maximum relative error that a quantile estimate will have (relative to the correct value).  This will initially be the same as the `max_error` used to construct the UddSketch, but if the sketch has needed to combine buckets this function will return the new maximum error.
 
-### Required Arguments [](uddsketch_error-required-arguments)
+### Required Arguments <a id="uddsketch_error-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `sketch` | `UddSketch` | The sketch to determine the error of. |
@@ -219,7 +219,7 @@ This returns the maximum relative error that a quantile estimate will have (rela
 | `uddsketch_error` | `DOUBLE PRECISION` | The maximum relative error of any quantile estimate. |
 <br>
 
-### Sample Usages [](uddsketch_error-examples)
+### Sample Usages <a id="uddsketch_error-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.error(
@@ -233,7 +233,7 @@ SELECT timescale_analytics_experimental.error(
 ```
 
 ---
-## **uddsketch_mean** [](uddsketch_mean)
+## **uddsketch_mean** <a id="uddsketch_mean"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.mean(sketch UddSketch) RETURNS DOUBLE PRECISION
@@ -241,7 +241,7 @@ timescale_analytics_experimental.mean(sketch UddSketch) RETURNS DOUBLE PRECISION
 
 Get the average of all the values contained in a UddSketch.
 
-### Required Arguments [](uddsketch_mean-required-arguments)
+### Required Arguments <a id="uddsketch_mean-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `sketch` | `UddSketch` |  The sketch to extract the mean value from. |
@@ -253,7 +253,7 @@ Get the average of all the values contained in a UddSketch.
 | `mean` | `DOUBLE PRECISION` | The average of the values entered into the UddSketch. |
 <br>
 
-### Sample Usage [](uddsketch_mean-examples)
+### Sample Usage <a id="uddsketch_mean-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.mean(
@@ -267,7 +267,7 @@ SELECT timescale_analytics_experimental.mean(
 ```
 
 ---
-## **uddsketch_quantile** [](uddsketch_quantile)
+## **uddsketch_quantile** <a id="uddsketch_quantile"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.quantile(
@@ -278,7 +278,7 @@ timescale_analytics_experimental.quantile(
 
 Get the approximate value at a quantile from a UddSketch.
 
-### Required Arguments [](uddsketch_quantile-required-arguments)
+### Required Arguments <a id="uddsketch_quantile-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `sketch` | `UddSketch` | The sketch to compute the quantile on. |
@@ -291,7 +291,7 @@ Get the approximate value at a quantile from a UddSketch.
 | `quantile` | `DOUBLE PRECISION` | The estimated value at the requested quantile. |
 <br>
 
-### Sample Usage [](uddsketch_quantile-examples)
+### Sample Usage <a id="uddsketch_quantile-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.quantile(
@@ -306,7 +306,7 @@ SELECT timescale_analytics_experimental.quantile(
 ```
 
 ---
-## **uddsketch_quantile_at_value** [](uddsketch_quantile_at_value)
+## **uddsketch_quantile_at_value** <a id="uddsketch_quantile_at_value"></a>
 
 ```SQL ,ignore
 timescale_analytics_experimental.quantile_at_value(
@@ -317,7 +317,7 @@ timescale_analytics_experimental.quantile_at_value(
 
 Estimate what quantile a given value would be located at in a UddSketch.
 
-### Required Arguments [](uddsketch_quantile_at_value-required-arguments)
+### Required Arguments <a id="uddsketch_quantile_at_value-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `sketch` | `UddSketch` | The sketch to compute the quantile on. |
@@ -330,7 +330,7 @@ Estimate what quantile a given value would be located at in a UddSketch.
 | `quantile_at_value` | `DOUBLE PRECISION` | The estimated quantile associated with the provided value. |
 <br>
 
-### Sample Usage [](uddsketch_quantile_at_value-examples)
+### Sample Usage <a id="uddsketch_quantile_at_value-examples"></a>
 
 ```SQL
 SELECT timescale_analytics_experimental.quantile_at_value(


### PR DESCRIPTION
Replace the style that we use in Timescale docs [](link) with the proper
HTML anchor divs throughout.