### PR TITLE
Add cache for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     - master
     - staging
     - trying
+  schedule:
+    # we build at 8am UTC, 3am Eastern, midnight Pacific
+    - cron:  '0 8 * * 1-4'
 
 jobs:
   test12:


### PR DESCRIPTION
This PR adds nightly runs of out test code, so that we'll have a cache on the main branch that PR runs can use when starting from scratch.

bors r+