### PR TITLE
Adding IMMUTABLE and PARALLEL SAFE to stable accessors

### DIFF
--- a/extension/docs/README.md
+++ b/extension/docs/README.md
@@ -19,5 +19,5 @@ The following links lead to pages for the different features in the Timescale An
 - [LTTB](lttb.md) [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes) – A downsample method that preserves visual similarity. ([Methods](lttb.md#api))
 
 - [Percentile Approximation](percentile_approximation.md) - A simple percentile approximation interface [([Methods](percentile_approximation.md#api))], wraps and simplifies the lower level algorithms:
-    - [T-Digest](tdigest.md) [<sup><mark>experimental</mark></sup>](/extension/docs/README.md#tag-notes) – A quantile estimate sketch optimized to provide more accurate estimates near the tails (i.e. 0.001 or 0.995) than conventional approaches. ([Methods](tdigest#tdigest_api))
+    - [T-Digest](tdigest.md) – A quantile estimate sketch optimized to provide more accurate estimates near the tails (i.e. 0.001 or 0.995) than conventional approaches. ([Methods](tdigest#tdigest_api))
     - [UddSketch](uddsketch.md) – A quantile estimate sketch which provides a guaranteed maximum relative error. ([Methods](uddsketch.md#uddsketch_api))

--- a/extension/docs/lttb.md
+++ b/extension/docs/lttb.md
@@ -19,6 +19,7 @@ In this example we're going to examine downsampling a 101 point cosine wave
 generated like so
 
 ```SQL ,non-transactional
+SET TIME ZONE 'UTC';
 CREATE TABLE sample_data(time TIMESTAMPTZ, val DOUBLE PRECISION);
 INSERT INTO sample_data
     SELECT

--- a/extension/docs/time_weighted_average.md
+++ b/extension/docs/time_weighted_average.md
@@ -21,6 +21,7 @@ For these examples we'll assume a table `foo` defined as follows, with a bit of 
 
 
 ```SQL ,non-transactional
+SET TIME ZONE 'UTC';
  CREATE TABLE foo (
     measure_id      BIGINT,
     ts              TIMESTAMPTZ ,

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -131,6 +131,18 @@ mod tests {
         "function tdigest_out(tdigest)",
         "function tdigest_serialize(internal)",
         "function tdigest_trans(internal,integer,double precision)",
-        "type tdigest"
+        "type tdigest",
+        "function average(timeweightsummary)",
+        "function time_weight(text,timestamp with time zone,double precision)",
+        "function time_weight(timeweightsummary)",
+        "function time_weight_combine(internal,internal)",
+        "function time_weight_final(internal)",
+        "function time_weight_summary_trans(internal,timeweightsummary)",
+        "function time_weight_trans(internal,text,timestamp with time zone,double precision)",
+        "function time_weight_trans_deserialize(bytea,internal)",
+        "function time_weight_trans_serialize(internal)",
+        "function timeweightsummary_in(cstring)",
+        "function timeweightsummary_out(timeweightsummary)",
+        "type timeweightsummary",
     ];
 }

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -307,7 +307,7 @@ CREATE AGGREGATE tdigest(
 //---- Available PG operations on the digest
 
 // Approximate the value at the given quantile (0.0-1.0)
-#[pg_extern(name="approx_percentile")]
+#[pg_extern(immutable, parallel_safe, name="approx_percentile")]
 pub fn tdigest_quantile(
     quantile: f64,
     digest: TDigest,
@@ -317,7 +317,7 @@ pub fn tdigest_quantile(
 }
 
 // Approximate the quantile at the given value
-#[pg_extern(name="approx_percentile_rank")]
+#[pg_extern(immutable, parallel_safe, name="approx_percentile_rank")]
 pub fn tdigest_quantile_at_value(
     value: f64,
     digest: TDigest,
@@ -327,7 +327,7 @@ pub fn tdigest_quantile_at_value(
 }
 
 // Number of elements from which the digest was built.
-#[pg_extern(name="num_vals")]
+#[pg_extern(immutable, parallel_safe, name="num_vals")]
 pub fn tdigest_count(
     digest: TDigest,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -336,7 +336,7 @@ pub fn tdigest_count(
 }
 
 // Minimum value entered in the digest.
-#[pg_extern(name="min_val")]
+#[pg_extern(immutable, parallel_safe, name="min_val")]
 pub fn tdigest_min(
     digest: TDigest,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -345,7 +345,7 @@ pub fn tdigest_min(
 }
 
 // Maximum value entered in the digest.
-#[pg_extern(name="max_val")]
+#[pg_extern(immutable, parallel_safe, name="max_val")]
 pub fn tdigest_max(
     digest: TDigest,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -355,7 +355,7 @@ pub fn tdigest_max(
 
 // Average of all the values entered in the digest.
 // Note that this is not an approximation, though there may be loss of precision.
-#[pg_extern(name="mean")]
+#[pg_extern(immutable, parallel_safe, name="mean")]
 pub fn tdigest_mean(
     digest: TDigest,
     _fcinfo: pg_sys::FunctionCallInfo,

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -266,7 +266,7 @@ CREATE AGGREGATE timescale_analytics_experimental.time_weight(tws timescale_anal
 "#
 );
 
-#[pg_extern(name = "average", schema = "timescale_analytics_experimental")]
+#[pg_extern(immutable, parallel_safe, name = "average", schema = "timescale_analytics_experimental")]
 pub fn time_weighted_average_average(
     tws: Option<timescale_analytics_experimental::TimeWeightSummary>,
     _fcinfo: pg_sys::FunctionCallInfo,

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -386,7 +386,7 @@ CREATE AGGREGATE percentile_agg(
 //---- Available PG operations on the sketch
 
 // Approximate the value at the given approx_percentile (0.0-1.0)
-#[pg_extern(name="approx_percentile")]
+#[pg_extern(immutable, parallel_safe, name="approx_percentile")]
 pub fn uddsketch_approx_percentile(
     percentile: f64,
     sketch: UddSketch,
@@ -401,7 +401,7 @@ pub fn uddsketch_approx_percentile(
 }
 
 // Approximate the approx_percentile at the given value
-#[pg_extern(name="approx_percentile_rank")]
+#[pg_extern(immutable, parallel_safe, name="approx_percentile_rank")]
 pub fn uddsketch_approx_percentile_rank(
     value: f64,
     sketch: UddSketch,
@@ -415,7 +415,7 @@ pub fn uddsketch_approx_percentile_rank(
 }
 
 // Number of elements from which the sketch was built.
-#[pg_extern(name="num_vals")]
+#[pg_extern(immutable, parallel_safe, name="num_vals")]
 pub fn uddsketch_num_vals(
     sketch: UddSketch,
 ) -> f64 {
@@ -424,7 +424,7 @@ pub fn uddsketch_num_vals(
 
 // Average of all the values entered in the sketch.
 // Note that this is not an approximation, though there may be loss of precision.
-#[pg_extern(name="mean")]
+#[pg_extern(immutable, parallel_safe, name="mean")]
 pub fn uddsketch_mean(
     sketch: UddSketch,
 ) -> f64 {
@@ -436,7 +436,7 @@ pub fn uddsketch_mean(
 }
 
 // The maximum error (relative to the true value) for any approx_percentile estimate.
-#[pg_extern(name="error")]
+#[pg_extern(immutable, parallel_safe, name="error")]
 pub fn uddsketch_error(
     sketch: UddSketch
 ) -> f64 {


### PR DESCRIPTION
This change also removes the experimental flag from time weighted averages.