### PR TITLE
Use newer Rust version in nightlies

### DIFF
--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -3,9 +3,10 @@ FROM timescale/timescaledb:latest-pg12 AS analytics-tools
 RUN mkdir rust
 
 RUN set -ex \
-    && apk add --no-cache --virtual .rust-build \
-        cargo \
-        clang-libs \
+    # add the edge tagged repository so we can get newer rust versions
+    && echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
+    && echo @edgecommunity http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
+    && apk add --no-cache \
         git \
         gcc \
         make \
@@ -13,9 +14,11 @@ RUN set -ex \
         openssl-dev \
         # we add rustup to get rustfmt (needed for pgx), but the version of rust
         # it installs does not support dynamic linking like the apk version
-        # does.
-        rust \
-        rustup \
+        # does. We use the 'edge' repo to get a new enough rust version.
+        clang-libs@edge \
+        cargo@edgecommunity \
+        rust@edgecommunity \
+        rustup@edgecommunity \
     && rustup-init -y --profile minimal -c rustfmt \
     # Add rustup components to the path for rustfmt to work. We need to use the
     # apk version of rust, to get dynamic linking, so add the rustup components


### PR DESCRIPTION
We want to use a newer rust version to take advantage of cargo improvements, and to use some of the newer panic handling functions. The current version of Alpine docker is using has an older one in the package manager, so we need to explicitly use the edge repo to get a newer version. We will likely wish to continue using the edge repo so we can update rust in the future without breaking nightlies.