### PR TITLE
Change base docker image to timescaledb-ha

### DIFF
--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -1,50 +1,40 @@
-FROM timescale/timescaledb:latest-pg12 AS analytics-tools
+FROM timescale/timescaledb-ha:pg13-latest AS analytics-tools
+
+USER root
 
 RUN mkdir rust
 
 RUN set -ex \
-    # add the edge tagged repository so we can get newer rust versions
-    && echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-    && echo @edgecommunity http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-    && apk add --no-cache \
-        git \
+    && apt-get update \
+    && apt-get install -y \
+        clang \
         gcc \
-        make \
-        openssl \
-        openssl-dev \
-        # we add rustup to get rustfmt (needed for pgx), but the version of rust
-        # it installs does not support dynamic linking like the apk version
-        # does. We use the 'edge' repo to get a new enough rust version.
-        clang-libs@edge \
-        cargo@edgecommunity \
-        rust@edgecommunity \
-        rustup@edgecommunity \
-    && rustup-init -y --profile minimal -c rustfmt \
-    # Add rustup components to the path for rustfmt to work. We need to use the
-    # apk version of rust, to get dynamic linking, so add the rustup components
-    # to the end of the path.
-    && PATH="${PATH}:/root/.cargo/bin" \
-    # install pgx.
-    && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
-    && cargo pgx init --pg12 /usr/local/bin/pg_config
+        git \
+        libssl-dev \
+        pkg-config \
+        postgresql-server-dev-13 \
+        make
 
-# we seperate out the build components so we we can just get them from cache
-# and don't need to fetch/build them each time
-FROM analytics-tools AS build-analytics
+ENV CARGO_HOME=/build/.cargo
+ENV RUSTUP_HOME=/build/.rustup
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --profile=minimal -c rustfmt
+ENV PATH="/build/.cargo/bin:${PATH}"
+
+#install pgx
+RUN set -ex \
+    && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
+    && cargo pgx init --pg13 /usr/lib/postgresql/13/bin/pg_config
 
 COPY . /rust/timescale-analytics
 
 RUN set -ex \
-    # Add rustup components to the path for rustfmt to work. We need to use the
-    # apk version of rust, to get dynamic linking, so add the rustup components
-    # to the end of the path.
-    && PATH="${PATH}:/root/.cargo/bin" \
     && cd /rust/timescale-analytics \
         && cd extension \
         && cargo pgx install --release
 
 # COPY over the new files to the image. Done as a seperate stage so we don't
 # ship the build tools.
-FROM timescale/timescaledb:latest-pg12 AS nightly
+FROM timescale/timescaledb-ha:pg13-latest AS nightly
 
-COPY --from=build-analytics /usr/local/ /usr/local/
+COPY --from=analytics-tools /usr/share/postgresql /usr/share/postgresql
+COPY --from=analytics-tools /usr/lib/postgresql /usr/lib/postgresql


### PR DESCRIPTION
This changes the base docker image to the fully featured docker image
`timescale/timescaledb-ha:pg13-latest`. This has a number of advantages
 1. It brings the nightly image more in-line with our eventual release
    channel.
 2. It brings the nightly image more in-line with the CI image, and
    improves the likelihood it'll be correct.
 3. The alpine-based Postgres image is a strange beast, with only
    partial support for collation (see issue #148 in the repo for more
    details). Switching to a Debian based image lets us avoid these
    issues.

It has the disadvantage that it results in a larger image, and we may
want to add the extension to the regular Alpine-based image in the
future to rectify this.