### PR TITLE
Add workflow_dispatch for nightly builds

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,6 +1,7 @@
 name: nightly
 
 on:
+  workflow_dispatch:
   schedule:
     # we build at 8am UTC, 3am Eastern, midnight Pacific
     - cron:  '0 8 * * 1-4'


### PR DESCRIPTION
This should allow us to manually trigger nightly builds from the GitHub UI, which will be useful if we break nightly builds and want to push a fast fix.