### PR TITLE
Run nightly action when PRs edit nightly and fix builder

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,6 +1,9 @@
 name: nightly
 
 on:
+  pull_request:
+    paths:
+      - 'docker/nightly/**'
   workflow_dispatch:
   schedule:
     # we build at 8am UTC, 3am Eastern, midnight Pacific
@@ -61,7 +64,7 @@ jobs:
         id: image_build
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ startsWith(github.event_name, 'cron') }}
           context: .
           file: ./docker/nightly/Dockerfile
           tags: timescaledev/timescale-analytics:nightly

--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -22,12 +22,18 @@ ENV PATH="/build/.cargo/bin:${PATH}"
 
 #install pgx
 RUN set -ex \
+    && rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
+    && chown postgres:postgres -R "${CARGO_HOME}" \
     && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
     && cargo pgx init --pg13 /usr/lib/postgresql/13/bin/pg_config
 
 COPY . /rust/timescale-analytics
 
 RUN set -ex \
+    && chown -R postgres:postgres /rust \
+    && chown postgres:postgres -R "${CARGO_HOME}" \
+    && chown postgres:postgres -R /usr/share/postgresql \
+    && chown postgres:postgres -R /usr/lib/postgresql \
     && cd /rust/timescale-analytics \
         && cd extension \
         && cargo pgx install --release


### PR DESCRIPTION
Run nightly action when PRs edit nightly but don't push to docker.

Fix nightly builds by `chown`ing the relevant directories.