### PR TITLE
Update flat-serialize version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,12 +461,12 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 [[package]]
 name = "flat_serialize"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=41c100c#41c100c41bb8ee8079b139c7c56d0f884394024c"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=15e8b4d#15e8b4d12f41d54a0c2235675e776fa38b02b709"
 
 [[package]]
 name = "flat_serialize_macro"
 version = "0.1.0"
-source = "git+https://github.com/JLockerman/flat_serialize?rev=41c100c#41c100c41bb8ee8079b139c7c56d0f884394024c"
+source = "git+https://github.com/JLockerman/flat_serialize?rev=15e8b4d#15e8b4d12f41d54a0c2235675e776fa38b02b709"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -37,11 +37,11 @@ rand_chacha = "0.3.0"
 
 [dependencies.flat_serialize]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "41c100c"
+rev = "15e8b4d"
 
 [dependencies.flat_serialize_macro]
 git = "https://github.com/JLockerman/flat_serialize"
-rev = "41c100c"
+rev = "15e8b4d"
 
 [dev-dependencies]
 pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}


### PR DESCRIPTION
The new version adds checks that `#[flat_serialize::flatten]` fields, and the fields following them have the correct alignment.