### PR TITLE
Adding timeseries aggregate

### DIFF
--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -166,4 +166,133 @@ pub fn lttb(data: &[TSPoint], threshold: usize) -> Cow<'_, [TSPoint]> {
     Cow::Owned(sampled)
 }
 
-// currently only have doctests, see docs/lttb
+#[pg_extern(name="lttb", schema = "timescale_analytics_experimental")]
+pub fn lttb_on_timeseries(
+    series: crate::time_series::timescale_analytics_experimental::TimeSeries<'static>,
+    threshold: i32,
+) -> Option<crate::time_series::timescale_analytics_experimental::TimeSeries<'static>> {
+    lttb_ts(series, threshold as usize).into()
+}
+
+// based on https://github.com/jeromefroe/lttb-rs version 0.2.0
+pub fn lttb_ts (data: crate::time_series::timescale_analytics_experimental::TimeSeries<'static>, threshold: usize)
+-> crate::time_series::timescale_analytics_experimental::TimeSeries<'static>
+{
+    if !data.is_sorted() {
+        panic!("lttb requires sorted timeseries");
+    }
+
+    if threshold >= data.num_points() || threshold == 0 {
+        // Nothing to do.
+        return data.clone();  // can we avoid this copy???
+    }
+
+    // let mut sampled = Vec::with_capacity(threshold);
+    let mut sampled = InternalTimeSeries::new_explicit_series();
+
+    // Bucket size. Leave room for start and end data points.
+    let every = ((data.num_points() - 2) as f64) / ((threshold - 2) as f64);
+
+    // Initially a is the first point in the triangle.
+    let mut a = 0;
+
+    // Always add the first point.
+    sampled.add_point(data.get(a).unwrap());
+
+    for i in 0..threshold - 2 {
+        // Calculate point average for next bucket (containing c).
+        let mut avg_x = 0i64;
+        let mut avg_y = 0f64;
+
+        let avg_range_start = (((i + 1) as f64) * every) as usize + 1;
+
+        let mut end = (((i + 2) as f64) * every) as usize + 1;
+        if end >= data.num_points() {
+            end = data.num_points();
+        }
+        let avg_range_end = end;
+
+        let avg_range_length = (avg_range_end - avg_range_start) as f64;
+
+        for i in 0..(avg_range_end - avg_range_start) {
+            let idx = (avg_range_start + i) as usize;
+            let point = data.get(idx).unwrap();
+            avg_x += point.ts;
+            avg_y += point.val;
+        }
+        avg_x /= avg_range_length as i64;
+        avg_y /= avg_range_length;
+
+        // Get the range for this bucket.
+        let range_offs = ((i as f64) * every) as usize + 1;
+        let range_to = (((i + 1) as f64) * every) as usize + 1;
+
+        // Point a.
+        let point_a_x = data.get(a).unwrap().ts;
+        let point_a_y = data.get(a).unwrap().val;
+
+        let mut max_area = -1f64;
+        let mut next_a = range_offs;
+        for i in 0..(range_to - range_offs) {
+            let idx = (range_offs + i) as usize;
+
+            // Calculate triangle area over three buckets.
+            let area = ((point_a_x - avg_x) as f64 * (data.get(idx).unwrap().val - point_a_y)
+                - (point_a_x - data.get(idx).unwrap().ts) as f64 * (avg_y - point_a_y))
+                .abs()
+                * 0.5;
+            if area > max_area {
+                max_area = area;
+                next_a = idx; // Next a is this b.
+            }
+        }
+
+        sampled.add_point(data.get(next_a).unwrap()); // Pick this point from the bucket.
+        a = next_a; // This a is the next a (chosen b).
+    }
+
+    // Always add the last point.
+    sampled.add_point(data.get(data.num_points() - 1).unwrap());
+
+    crate::time_series::timescale_analytics_experimental::TimeSeries::from_internal_time_series(&sampled)
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+    
+    #[pg_test]
+    fn test_lttb_equivalence() {
+        Spi::execute(|client| {
+            client.select("CREATE TABLE test(time TIMESTAMPTZ, value DOUBLE PRECISION);", None, None);
+            client.select(
+                "INSERT INTO test 
+                SELECT time, value 
+                FROM timescale_analytics_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, NULL);", None, None);
+
+            client.select("CREATE TABLE results1(time TIMESTAMPTZ, value DOUBLE PRECISION);", None, None);
+            client.select(
+                "INSERT INTO results1 
+                SELECT time, value 
+                FROM timescale_analytics_experimental.unnest_series(
+                    (SELECT timescale_analytics_experimental.lttb(time, value, 100) FROM test)
+                );", None, None);
+
+            client.select("CREATE TABLE results2(time TIMESTAMPTZ, value DOUBLE PRECISION);", None, None);
+            client.select(
+                "INSERT INTO results2
+                SELECT time, value 
+                FROM timescale_analytics_experimental.unnest_series(
+                    (SELECT timescale_analytics_experimental.lttb(
+                        (SELECT timescale_analytics_experimental.timeseries(time, value) FROM test), 100)
+                    )
+                );", None, None);
+
+            let delta = client
+                .select("SELECT count(*)  FROM results1 r1 FULL OUTER JOIN results2 r2 ON r1 = r2 WHERE r1 IS NULL OR r2 IS NULL;" , None, None)
+                .first()
+                .get_one::<i32>();
+            assert_eq!(delta.unwrap(), 0);
+        })
+    }
+}

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -1,13 +1,18 @@
 
+use std::{slice};
+
 use pgx::*;
 
 use crate::{
-    json_inout_funcs, pg_type, flatten,
+    aggregate_utils::in_aggregate_context, json_inout_funcs, pg_type, flatten, palloc::Internal,
 };
 
 use time_series::{TSPoint, TimeSeries as InternalTimeSeries, ExplicitTimeSeries, NormalTimeSeries};
 
 use flat_serialize::*;
+
+#[allow(non_camel_case_types)]
+type bytea = pg_sys::Datum;
 
 pg_type! {
     #[derive(Debug)]
@@ -23,6 +28,11 @@ pg_type! {
                 step_interval: i64,
                 num_vals: u64,  // required to be aligned
                 values: [f64; self.num_vals],
+            },
+            // ExplicitSeries is assumed to be unordered
+            ExplicitSeries: 3 {
+                num_points: u64,  // required to be aligned
+                points: [TSPoint; self.num_points],
             },
         },
     }
@@ -47,6 +57,14 @@ impl<'input> TimeSeries<'input> {
                         points: points.to_vec(),
                     }
                 ),
+            // This is assumed unordered
+            SeriesType::ExplicitSeries{points, ..} =>
+                    InternalTimeSeries::Explicit(
+                        ExplicitTimeSeries {
+                            ordered: false,
+                            points: points.to_vec(),
+                        }
+                    ),
             SeriesType::NormalSeries{start_ts, step_interval, values, ..} =>
                 InternalTimeSeries::Normal(
                     NormalTimeSeries {
@@ -58,21 +76,40 @@ impl<'input> TimeSeries<'input> {
         }
     }
 
+    pub fn num_points(&self) -> usize {
+        match self.series {
+            SeriesType::SortedSeries{points, ..} =>
+                points.len(),
+            SeriesType::ExplicitSeries{points, ..} =>
+                points.len(),
+            SeriesType::NormalSeries{values, ..} =>
+                values.len(),
+        }
+    }
+
     pub fn from_internal_time_series(series: &InternalTimeSeries) -> TimeSeries<'input> {
         unsafe {
             match series {
                 InternalTimeSeries::Explicit(series) => {
                     if !series.ordered {
-                        panic!("No time series type for unordered point yet");
-                    }
-                    flatten!(
-                        TimeSeries {
-                            series: SeriesType::SortedSeries {
-                                num_points: &(series.points.len() as u64),
-                                points: &series.points,
+                        flatten!(
+                            TimeSeries {
+                                series: SeriesType::ExplicitSeries {
+                                    num_points: &(series.points.len() as u64),
+                                    points: &series.points,
+                                }
                             }
-                        }
-                    )
+                        )
+                    } else {
+                        flatten!(
+                            TimeSeries {
+                                series: SeriesType::SortedSeries {
+                                    num_points: &(series.points.len() as u64),
+                                    points: &series.points,
+                                }
+                            }
+                        )
+                    }
                 },
                 InternalTimeSeries::Normal(series) => {
                     flatten!(
@@ -89,6 +126,34 @@ impl<'input> TimeSeries<'input> {
             }
         }
     }
+
+    // Gets the nth point of a timeseries
+    // Differs from normal vector get in that it returns a copy rather than a reference (as the point may have to be constructed)
+    pub fn get(&self, index: usize) -> Option<TSPoint> {
+        if index >= self.num_points() {
+            return None;
+        }
+
+        match self.series {
+            SeriesType::SortedSeries{points, ..} =>
+                Some(points[index]),
+            SeriesType::ExplicitSeries{points, ..} =>
+                Some(points[index]),
+            SeriesType::NormalSeries{start_ts, step_interval, values, ..} =>
+                Some(TSPoint{ts: start_ts + index as i64 * step_interval, val: values[index]}),
+        }
+    }
+
+    pub fn is_sorted(&self) -> bool {
+        match self.series {
+            SeriesType::SortedSeries{..} =>
+                true,
+            SeriesType::ExplicitSeries{..} =>
+                false, // a sorted ExplicitSeries is written out as a SortedSeries
+            SeriesType::NormalSeries{..} =>
+                true,
+        }
+    }
 }
 
 #[pg_extern(schema = "timescale_analytics_experimental")]
@@ -97,6 +162,9 @@ pub fn unnest_series(
 ) -> impl std::iter::Iterator<Item = (name!(time,pg_sys::TimestampTz),name!(value,f64))> + '_ {
     let iter: Box<dyn Iterator<Item=_>> = match series.series {
         SeriesType::SortedSeries{points, ..} =>
+            Box::new(points.iter().map(|points| (points.ts, points.val))),
+
+        SeriesType::ExplicitSeries{points, ..} =>
             Box::new(points.iter().map(|points| (points.ts, points.val))),
 
         SeriesType::NormalSeries{start_ts, step_interval, num_vals, values} =>
@@ -108,3 +176,91 @@ pub fn unnest_series(
     };
     iter
 }
+
+#[pg_extern(schema = "timescale_analytics_experimental")]
+pub fn timeseries_serialize(
+    state: Internal<InternalTimeSeries>,
+) -> bytea {
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "timescale_analytics_experimental",strict)]
+pub fn timeseries_deserialize(
+    bytes: bytea,
+    _internal: Option<Internal<()>>,
+) -> Internal<InternalTimeSeries> {
+    crate::do_deserialize!(bytes, InternalTimeSeries)
+}
+
+#[pg_extern(schema = "timescale_analytics_experimental")]
+pub fn timeseries_trans(
+    state: Option<Internal<InternalTimeSeries>>,
+    time: Option<pg_sys::TimestampTz>,
+    value: Option<f64>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal<InternalTimeSeries>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let time = match time {
+                None => return state,
+                Some(time) => time,
+            };
+            let value = match value {
+                None => return state,   // Should we support NULL values?
+                Some(value) => value,
+            };
+            let mut state = match state {
+                None => InternalTimeSeries::new_explicit_series().into(),
+                Some(state) => state,
+            };
+            state.add_point(TSPoint{ts: time, val:value});
+            Some(state)
+        })
+    }
+}
+
+#[pg_extern(schema = "timescale_analytics_experimental")]
+pub fn timeseries_combine (
+    state1: Option<Internal<InternalTimeSeries>>,
+    state2: Option<Internal<InternalTimeSeries>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal<InternalTimeSeries>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            match (state1, state2) {
+                (None, None) => None,
+                (None, Some(state2)) => Some(state2.clone().into()),
+                (Some(state1), None) => Some(state1.clone().into()),
+                (Some(state1), Some(state2)) =>
+                    Some(InternalTimeSeries::combine(&state1, &state2).into())
+            }
+        })
+    }
+}
+
+#[pg_extern(schema = "timescale_analytics_experimental")]
+pub fn timeseries_final(
+    state: Option<Internal<InternalTimeSeries>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<crate::time_series::timescale_analytics_experimental::TimeSeries<'static>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let state = match state {
+                None => return None,
+                Some(state) => state,
+            };
+            TimeSeries::from_internal_time_series(&state).into()
+        })
+    }
+}
+
+extension_sql!(r#"
+CREATE AGGREGATE timescale_analytics_experimental.timeseries(ts TIMESTAMPTZ, value DOUBLE PRECISION) (
+    sfunc = timescale_analytics_experimental.timeseries_trans,
+    stype = internal,
+    finalfunc = timescale_analytics_experimental.timeseries_final,
+    combinefunc = timescale_analytics_experimental.timeseries_combine,
+    serialfunc = timescale_analytics_experimental.timeseries_serialize,
+    deserialfunc = timescale_analytics_experimental.timeseries_deserialize
+);
+"#);


### PR DESCRIPTION
This change adds a postgres aggregate to construct a timeseries object directly
from a time and value column.  It also adds implementations for LTTB and ASAP
to operate directly on such timeseries aggregates.