### PR TITLE
Add time-weighted average UI tests

### DIFF
--- a/crates/time-series/src/lib.rs
+++ b/crates/time-series/src/lib.rs
@@ -1,9 +1,9 @@
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeStruct};
 
-use std::borrow::Cow;
+use std::{borrow::Cow, ffi::CStr};
 
-#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 #[repr(C)]
 pub struct TSPoint {
     pub ts: i64,
@@ -24,6 +24,121 @@ impl TSPoint {
         let duration = (p2.ts - self.ts) as f64; // x2 - x1
         let dinterp = (ts - self.ts) as f64; // x - x1
         Ok((p2.val - self.val) * dinterp / duration + self.val)
+    }
+}
+
+impl Serialize for TSPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer {
+        if serializer.is_human_readable() {
+            // FIXME ugly hack to use postgres functions in an non-postgres library
+            extern "C" {
+                fn _ts_toolkit_encode_timestamptz(dt: i64, buf: &mut [u8; 128]);
+            }
+            let mut ts = [0; 128];
+            unsafe {
+                _ts_toolkit_encode_timestamptz(self.ts, &mut ts);
+            }
+            let end = ts.iter().position(|c| *c == 0).unwrap();
+            let ts = CStr::from_bytes_with_nul(&ts[..end+1]).unwrap();
+            let ts = ts.to_str().unwrap();
+            let mut point = serializer.serialize_struct("TSPoint", 2)?;
+            point.serialize_field("ts", &ts)?;
+            point.serialize_field("val", &self.val)?;
+            point.end()
+        } else {
+            let mut point = serializer.serialize_struct("TSPoint", 2)?;
+            point.serialize_field("ts", &self.ts)?;
+            point.serialize_field("val", &self.val)?;
+            point.end()
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TSPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de> {
+
+        use std::fmt;
+        use serde::de::{self, Visitor, SeqAccess, MapAccess};
+        struct TsPointVisitor{ text_timestamp: bool }
+
+        // FIXME ugly hack to use postgres functions in an non-postgres library
+        extern "C" {
+            // this is only going to be used to communicate with a rust lib we compile with this one
+            #[allow(improper_ctypes)]
+            fn _ts_toolkit_decode_timestamptz(text: &str) -> i64;
+        }
+
+        impl<'de> Visitor<'de> for TsPointVisitor {
+            type Value = TSPoint;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct TSPoint")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<TSPoint, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let ts = if self.text_timestamp {
+                    let text: &str = seq.next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                    unsafe {
+                        _ts_toolkit_decode_timestamptz(text)
+                    }
+                } else {
+                    seq.next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(0, &self))?
+                };
+                let val = seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                Ok(TSPoint{ ts, val })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<TSPoint, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                #[serde(field_identifier, rename_all = "lowercase")]
+                enum Field { Ts, Val }
+                let mut ts = None;
+                let mut val = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Ts => {
+                            if ts.is_some() {
+                                return Err(de::Error::duplicate_field("ts"));
+                            }
+                            ts = if self.text_timestamp {
+                                let text: &str = map.next_value()?;
+                                unsafe {
+                                    Some(_ts_toolkit_decode_timestamptz(text))
+                                }
+                            } else {
+                                Some(map.next_value()?)
+                            };
+                        }
+                        Field::Val => {
+                            if val.is_some() {
+                                return Err(de::Error::duplicate_field("val"));
+                            }
+                            val = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let ts = ts.ok_or_else(|| de::Error::missing_field("ts"))?;
+                let val = val.ok_or_else(|| de::Error::missing_field("val"))?;
+                Ok(TSPoint{ ts, val })
+            }
+        }
+        const FIELDS: &'static [&'static str] = &["ts", "val"];
+
+        let visitor = TsPointVisitor { text_timestamp: deserializer.is_human_readable() };
+        deserializer.deserialize_struct("TSPoint", FIELDS, visitor)
     }
 }
 

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -345,7 +345,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_time_weight_aggregate_io() {
+    fn test_time_weight_io() {
         Spi::execute(|client| {
             let stmt = "CREATE TABLE test(ts timestamptz, val DOUBLE PRECISION)";
             client.select(stmt, None, None);
@@ -361,8 +361,8 @@ mod tests {
             // test basic with 2 points
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631152060000000,\"val\":20.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:01:00+00\",\"val\":20.0},\
                 \"weighted_sum\":900000000.0,\
                 \"method\":\"Linear\"\
             }";
@@ -371,8 +371,8 @@ mod tests {
 
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631152060000000,\"val\":20.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:01:00+00\",\"val\":20.0},\
                 \"weighted_sum\":600000000.0,\
                 \"method\":\"LOCF\"\
             }";
@@ -385,8 +385,8 @@ mod tests {
 
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631152240000000,\"val\":10.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:04:00+00\",\"val\":10.0},\
                 \"weighted_sum\":3600000000.0,\
                 \"method\":\"Linear\"\
             }";
@@ -394,8 +394,8 @@ mod tests {
             assert_eq!(select_one!(client, &*avg(expected), f64), 15.0);
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631152240000000,\"val\":10.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:04:00+00\",\"val\":10.0},\
                 \"weighted_sum\":3600000000.0,\
                 \"method\":\"LOCF\"\
             }";
@@ -408,16 +408,16 @@ mod tests {
 
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631153200000000,\"val\":30.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:20:00+00\",\"val\":30.0},\
                 \"weighted_sum\":25500000000.0,\"method\":\"Linear\"\
             }";
             assert_eq!(select_one!(client, linear_time_weight, String), expected);
             assert_eq!(select_one!(client, &*avg(expected), f64), 21.25);
             let expected = "{\
                 \"version\":1,\
-                \"first\":{\"ts\":631152000000000,\"val\":10.0},\
-                \"last\":{\"ts\":631153200000000,\"val\":30.0},\
+                \"first\":{\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                \"last\":{\"ts\":\"2020-01-01 00:20:00+00\",\"val\":30.0},\
                 \"weighted_sum\":21300000000.0,\"method\":\"LOCF\"\
             }";
             assert_eq!(select_one!(client, locf_time_weight, String), expected);


### PR DESCRIPTION
This PR adds UI tests time-weighted average, ensuring that our textual representation of them will remain consistent.

This PR also adds textual serialization and deserialization to `TSPoint` when it's being in/output to a human-readable format. Outputting the integer representation of Postgres timestamps isn't particularly usable to human beings, nor consumable by non-Postgres software, and this work better for both vases.

The translation is done by an in-tree copy of `timestamptz_in`/`out`. Since we only link to Postgres in the top-level extension crate, we currently use undefined symbol hackery in crates/time-series to make this work. Long-term, we should likely move it, and its transitive dependencies into the extension crate.
