### PR TITLE
Rename the extension to TimescaleDB Toolkit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 **Relevant system information:**
  - OS: [e.g. Ubuntu 16.04, Windows 10 x64, etc]
  - PostgreSQL version (output of `SELECT version();`): [e.g. 12.0, 13.2, etc]
- - Timescale Analytics version (output of `\dx timescale_analytics` in `psql`): [e.g. 1.0.0]
+ - TimescaleDB Toolkit version (output of `\dx timescaledb_toolkit` in `psql`): [e.g. 1.0.0]
  - Installation method: [e.g., "Timescale Forge", "docker", "source"]
 
 **Describe the bug**
@@ -34,4 +34,3 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Run Doc Tests
       run: |
         sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg12 && /usr/local/cargo/bin/cargo pgx start pg12"
-        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescale_analytics; SET SESSION TIMEZONE TO 'UTC'" -p 28812 docs
+        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28812 docs
 
 
   test13:
@@ -116,4 +116,4 @@ jobs:
     - name: Run Doc Tests
       run: |
         sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg13 && /usr/local/cargo/bin/cargo pgx start pg13"
-        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescale_analytics; SET SESSION TIMEZONE TO 'UTC'" -p 28813 docs
+        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28813 docs

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -40,22 +40,22 @@ jobs:
       #   id: tester_build
       #   uses: docker/build-push-action@v2
       #   with:
-      #     target: analytics-tools
+      #     target: toolkit-tools
       #     push: false
       #     load: true
       #     context: .
       #     file: ./docker/nightly/Dockerfile
-      #     tags: timescaledev/timescale-analytics:tester
+      #     tags: timescaledev/timescaledb-toolkit:tester
       #     cache-from: type=local,src=/tmp/.buildx-cache
       #     cache-to: type=local,dest=/tmp/.buildx-cache
 
       # - name: Run Tests
       #   run: |
-      #       docker run -d --name ts_analytics_test -e POSTGRES_HOST_AUTH_METHOD=trust timescaledev/timescale-analytics:tester
-      #       docker exec ts_analytics_test /bin/bash -c 'PATH=\"${PATH}:/root/.cargo/bin\" \
-      #         && cd /rust/timescale-analytics/crates \
-      #         && cargo test --release --workspace --exclude timescale_analytics'
-      #       docker stop ts_analytics_test
+      #       docker run -d --name toolkit_test -e POSTGRES_HOST_AUTH_METHOD=trust timescaledev/timescaledb-toolkit:tester
+      #       docker exec toolkit_test /bin/bash -c 'PATH=\"${PATH}:/root/.cargo/bin\" \
+      #         && cd /rust/timescaledb-analytics/crates \
+      #         && cargo test --release --workspace --exclude timescaledb_toolkit'
+      #       docker stop toolkit_test
       # TODO we also want to run our extension tests, but we don't want to restart the DB, need a pgx patch
 
       #TODO run doctests
@@ -67,7 +67,7 @@ jobs:
           push: ${{ startsWith(github.event_name, 'cron') }}
           context: .
           file: ./docker/nightly/Dockerfile
-          tags: timescaledev/timescale-analytics:nightly
+          tags: timescaledev/timescaledb-toolkit:nightly
 
       - name: Image digest
         run: echo ${{ steps.image_build.outputs.digest }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "timescale_analytics"
+name = "timescaledb_toolkit"
 version = "0.3.0"
 dependencies = [
  "approx",

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-TimescaleDB-Analytics (TM)
+TimescaleDB-Toolkit (TM)
 
 Copyright (c) 2021  Timescale, Inc. All Rights Reserved.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,13 +1,13 @@
-# Timescale Analytics #
+# TimescaleDB Toolkit #
 
-This repository is the home of the Timescale Analytics team. Our mission is to
+This repository is the home of the TimescaleDB Toolkit team. Our mission is to
 ease all things analytics when using TimescaleDB, with a particular focus on
 developer ergonomics and performance. Our issue tracker contains more
 on [the features we're planning to work on](https://github.com/timescale/timescale-analytics/labels/proposed-feature)
 and [the problems we're trying to solve](https://github.com/timescale/timescale-analytics/labels/feature-request),
 and our [Discussions forum](https://github.com/timescale/timescale-analytics/discussions) contains ongoing conversation.
 
-Documentation for this version of the Timescale Analytics extension can be found
+Documentation for this version of the TimescaleDB Toolkit extension can be found
 in this repository at [`docs`](https://github.com/timescale/timescale-analytics/tree/main/docs).
 
 
@@ -15,9 +15,9 @@ in this repository at [`docs`](https://github.com/timescale/timescale-analytics/
 
 The extension comes pre-installed on all [Timescale Forge](https://console.forge.timescale.com/) instances, and also on our full-featured [`timescale/timescaledb-ha` docker image](https://hub.docker.com/r/timescale/timescaledb-ha).
 
-We also provide nightly builds as a docker images in `timescaledev/timescale-analytics:nightly`.
+We also provide nightly builds as a docker images in `timescaledev/timescaledb-toolkit:nightly`.
 
-All versions of the extension contain experimental features in the `timecale_analytics_experimental`, schema see [our docs section on experimental features](/docs/README.md#tag-notes) for
+All versions of the extension contain experimental features in the `toolkit_experimental`, schema see [our docs section on experimental features](/docs/README.md#tag-notes) for
 more details.
 
 ## 💿 Installing From Source ##
@@ -53,7 +53,7 @@ cargo run --manifest-path ./tools/post-install/Cargo.toml --  /path/to/your/pg_c
 
 ## ✏️ Get Involved ##
 
-The Timescale Analytics project is still in the initial planning stage as we
+The TimescaleDB Toolkit project is still in the initial planning stage as we
 decide our priorities and what to implement first. As such, now is a great time
 to help shape the project's direction! Have a look at the
 [list of features we're thinking of working on](https://github.com/timescale/timescale-analytics/labels/proposed-feature)
@@ -73,7 +73,7 @@ cargo install --git https://github.com/JLockerman/pgx.git --branch timescale car
 
 Once you have `pgx` installed, clone this repo and swich into the extension directory, e.g
 ```bash
-cd timescale_analytics/extension
+cd timescaledb_toolkit/extension
 ```
 you can run tests against a postgres version
 `pg12`, or `pg13` using

--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM timescale/timescaledb-ha:pg13-latest AS analytics-tools
+FROM timescale/timescaledb-ha:pg13-latest AS toolkit-tools
 
 USER root
 
@@ -43,5 +43,5 @@ RUN set -ex \
 # ship the build tools.
 FROM timescale/timescaledb-ha:pg13-latest AS nightly
 
-COPY --from=analytics-tools /usr/share/postgresql /usr/share/postgresql
-COPY --from=analytics-tools /usr/lib/postgresql /usr/lib/postgresql
+COPY --from=toolkit-tools /usr/share/postgresql /usr/share/postgresql
+COPY --from=toolkit-tools /usr/lib/postgresql /usr/lib/postgresql

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,18 @@
-# Timescale Analytics Documentation
+# TimescaleDB Toolkit Documentation
 ---
-The Timescale Analytics project contains a number of utilities for working with time-series data.  This documentation is further broken down by utility or feature in the list [below](#analytics-features).
+The TimescaleDB Toolkit project contains a number of utilities for working with time-series data.  This documentation is further broken down by utility or feature in the list [below](#toolkit-features).
 
 ## A note on tags <a id="tag-notes"></a>
-Functionality within the Timescale Analytics repository is intended to be introduced in varying stages of completeness.  To clarify which releases a given feature or function can be found in, the following tags are used:
- - **Experimental** - Denotes functionality that is still under very active development and may have poor performance, not handle corner cases or errors, etc.  Experimental APIs will change across releases, and extension-update will drop database objects that depend on experimental features. Do not use them unless you're willing ot deal with the object you've created (the view, table, continuous aggregates, function, etc.) being dropped on update. This is particularly important for managed cloud services (like Timescale Forge) that automate upgrades. Experimental features and functions can be found exclusively in the `timescale_analytics_experimental` schema.
+Functionality within the TimescaleDB Toolkit repository is intended to be introduced in varying stages of completeness.  To clarify which releases a given feature or function can be found in, the following tags are used:
+ - **Experimental** - Denotes functionality that is still under very active development and may have poor performance, not handle corner cases or errors, etc.  Experimental APIs will change across releases, and extension-update will drop database objects that depend on experimental features. Do not use them unless you're willing ot deal with the object you've created (the view, table, continuous aggregates, function, etc.) being dropped on update. This is particularly important for managed cloud services (like Timescale Forge) that automate upgrades. Experimental features and functions can be found exclusively in the `toolkit_experimental` schema.
  - **Stable** ***release id*** - Functionality in this state should be correct and performant.  Stable APIs will be found in our releases and should not be broken in future releases.  Note that this tag will also be accompanied with the version in which the feature was originally released, such as: Feature Foo<sup><mark>stable-1.2</mark></sup>.
  - **Deprecated** - It may be necessary to remove stable functionality at some point, for instance if it is being supplanted by newer functionality or if it has deprecated dependencies.  Functionality with this tag is expected to be removed in future releases and current users of it should move to alternatives.
 
 Note that tags can be applied at either a feature or function scope.  The function tag takes precedence, but defaults to the feature scope if not present.  For example, if we have a feature `Foo` which is tagged `stable`, we would assume that an untagged function `FooCount` within that feature would be present in the current beta release.  However, if function `FooSum` were explicitly tagged `experimental` then we would only expect to find it in the nightly build.
 
-## Analytics features <a id="analytics-features"></a>
+## Features <a id="toolkit-features"></a>
 
-The following links lead to pages for the different features in the Timescale Analytics repository.
+The following links lead to pages for the different features in the TimescaleDB Toolkit repository.
 
 - [ASAP Smoothing](asap.md) [<sup><mark>experimental</mark></sup>](/docs/README.md#tag-notes) - A data smoothing algorithm designed to generate human readable graphs which maintain any erratic data behavior while smoothing away the cyclic noise.
 - [Hyperloglog](hyperloglog.md) [<sup><mark>experimental</mark></sup>](/docs/README.md#tag-notes) – An approximate `COUNT DISTINCT` based on hashing that provides reaonable accuracy in constant space. ([Methods](hyperloglog.md#hyperloglog_api))

--- a/docs/asap.md
+++ b/docs/asap.md
@@ -7,7 +7,7 @@
 
 ## Description <a id="asap-description"></a>
 
-The [ASAP smoothing alogrithm](https://arxiv.org/pdf/1703.00983.pdf) is designed create human readable graphs which preserve the rough shape and larger trends of the input data while minimizing the local variance between points.  Timescale analytics provides an implementation of this which will take `(timestamp, value)` pairs, normalize them to the target interval, and return the ASAP smoothed values.
+The [ASAP smoothing alogrithm](https://arxiv.org/pdf/1703.00983.pdf) is designed create human readable graphs which preserve the rough shape and larger trends of the input data while minimizing the local variance between points.  TimescaleDB Toolkit provides an implementation of this which will take `(timestamp, value)` pairs, normalize them to the target interval, and return the ASAP smoothed values.
 
 ## Details <a id="asap-details"></a>
 
@@ -17,7 +17,7 @@ The output of the postgres aggregate is a timescale timeseries object describing
 
 ## Usage Example <a id="asap-example"></a>
 
-In this example we're going to examine about 250 years of monthly temperature readings from England (raw data can be found [here](http://futuredata.stanford.edu/asap/Temp.csv), though timestamps need to have a day added to be readable by PostgresQL).  
+In this example we're going to examine about 250 years of monthly temperature readings from England (raw data can be found [here](http://futuredata.stanford.edu/asap/Temp.csv), though timestamps need to have a day added to be readable by PostgresQL).
 
 
 ```SQL ,ignore
@@ -26,7 +26,7 @@ COPY temperatures from 'temperature.csv' CSV HEADER;
 SELECT * FROM temperatures ORDER BY month LIMIT 10;
 ```
 ```
-            month             | value 
+            month             | value
 ------------------------------+-------
  1723-01-01 00:00:00-07:52:58 |   1.1
  1723-02-01 00:00:00-07:52:58 |   4.4
@@ -48,10 +48,10 @@ It is hard to look at this data and make much sense of how the temperature has c
 We can use ASAP smoothing here to get a much clearer picture of the behavior over this interval.
 
 ```SQL ,ignore
-SELECT * FROM timescale_analytics_experimental.unnest_series((SELECT timescale_analytics_experimental.asap_smooth(month, value, 800) FROM temperatures));
+SELECT * FROM toolkit_experimental.unnest_series((SELECT toolkit_experimental.asap_smooth(month, value, 800) FROM temperatures));
 ```
 ```
-                time                 |       value       
+                time                 |       value
 -------------------------------------+-------------------
  1723-01-01 00:00:00-07:52:58        |  9.51550387596899
  1723-04-12 21:38:55.135135-07:52:58 |   9.4890503875969
@@ -81,7 +81,7 @@ Note the use of the `unnest_series` here to unpack the results of the `asap_smoo
 ---
 ## **asap_smooth** <a id="asap_smooth"></a>
 ```SQL ,ignore
-timescale_analytics_experimental.asap_smooth(
+toolkit_experimental.asap_smooth(
     ts TIMESTAMPTZ,
     value DOUBLE PRECISION,
     resolution INT
@@ -113,9 +113,9 @@ For this examples assume we have a table 'metrics' with columns 'date' and 'read
 ```SQL ,non-transactional
 SET TIME ZONE 'UTC';
 CREATE TABLE metrics(date TIMESTAMPTZ, reading DOUBLE PRECISION);
-INSERT INTO metrics 
+INSERT INTO metrics
 SELECT
-    '2020-1-1 UTC'::timestamptz + make_interval(hours=>foo), 
+    '2020-1-1 UTC'::timestamptz + make_interval(hours=>foo),
     (5 + 5 * sin(foo / 12.0 * PI()))
     FROM generate_series(1,168) foo;
 
@@ -124,12 +124,12 @@ SELECT
 </div>
 
 ```SQL
-SELECT * FROM timescale_analytics_experimental.unnest_series(
-    (SELECT timescale_analytics_experimental.asap_smooth(date, reading, 8)
+SELECT * FROM toolkit_experimental.unnest_series(
+    (SELECT toolkit_experimental.asap_smooth(date, reading, 8)
      FROM metrics));
 ```
 ```output
-          time          |        value        
+          time          |        value
 ------------------------+---------------------
  2020-01-01 01:00:00+00 | 5.3664814565722665
  2020-01-01 21:00:00+00 |  5.949469264090644

--- a/docs/hyperloglog.md
+++ b/docs/hyperloglog.md
@@ -6,7 +6,7 @@
 
 ## Description <a id="hyperloglog-description"></a>
 
-Timescale analytics provides an implementation of the [Hyperloglog estimator](https://en.wikipedia.org/wiki/HyperLogLog) for `COUNT DISTINCT` approximations of any type that has a hash function.
+TimescaleDB Toolkit provides an implementation of the [Hyperloglog estimator](https://en.wikipedia.org/wiki/HyperLogLog) for `COUNT DISTINCT` approximations of any type that has a hash function.
 
 ## Details <a id="hyperloglog-details"></a>
 
@@ -20,7 +20,7 @@ Timescale's HyperLogLog is implemented as an aggregate function in PostgreSQL.  
 ---
 ## **hyperloglog** <a id="hyperloglog"></a>
 ```SQL,ignore
-timescale_analytics_experimental.hyperloglog(
+toolkit_experimental.hyperloglog(
     size INTEGER,
     value AnyElement¹
 ) RETURNS TDigest
@@ -47,13 +47,13 @@ This will construct and return a Hyperloglog with at least the specified number 
 For this examples assume we have a table 'samples' with a column 'weights' holding `DOUBLE PRECISION` values.  The following will simply return a digest over that column
 
 ```SQL ,ignore
-SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
+SELECT toolkit_experimental.hyperloglog(64, data) FROM samples;
 ```
 
 It may be more useful to build a view from the aggregate that we can later pass to other tdigest functions.
 
 ```SQL ,ignore
-CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, data) FROM samples;
+CREATE VIEW digest AS SELECT toolkit_experimental.hyperloglog(64, data) FROM samples;
 ```
 
 ---
@@ -61,7 +61,7 @@ CREATE VIEW digest AS SELECT timescale_analytics_experimental.hyperloglog(64, da
 ## **hyperloglog_count** <a id="hyperloglog_count"></a>
 
 ```SQL ,ignore
-timescale_analytics_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
+toolkit_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
 ```
 
 Get the number of distinct values from a hyperloglog.
@@ -82,7 +82,7 @@ Get the number of distinct values from a hyperloglog.
 ### Sample Usages <a id="hyperloglog_count-examples"></a>
 
 ```SQL
-SELECT timescale_analytics_experimental.hyperloglog_count(timescale_analytics_experimental.hyperloglog(64, data))
+SELECT toolkit_experimental.hyperloglog_count(toolkit_experimental.hyperloglog(64, data))
 FROM generate_series(1, 100) data
 ```
 ```output

--- a/docs/lttb.md
+++ b/docs/lttb.md
@@ -8,7 +8,7 @@
 
 [Largest Triangle Three Buckets](https://github.com/sveinn-steinarsson/flot-downsample)
 is a downsampling method that tries to retain visual similarity between the
-downsampled data and the original dataset. Timescale analytics provides an
+downsampled data and the original dataset. TimescaleDB Toolkit provides an
 implementation of this which takes `(timestamp, value)` pairs, sorts them if
 needed, and downsamples them.
 
@@ -40,8 +40,8 @@ to 34 points
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM timescale_analytics_experimental.unnest_series((
-    SELECT timescale_analytics_experimental.lttb(time, val, 34)
+FROM toolkit_experimental.unnest_series((
+    SELECT toolkit_experimental.lttb(time, val, 34)
     FROM sample_data))
 ```
 
@@ -101,8 +101,8 @@ resulting data looks less and less like the original
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM timescale_analytics_experimental.unnest_series((
-    SELECT timescale_analytics_experimental.lttb(time, val, 17)
+FROM toolkit_experimental.unnest_series((
+    SELECT toolkit_experimental.lttb(time, val, 17)
     FROM sample_data))
 ```
 ```output
@@ -132,8 +132,8 @@ FROM timescale_analytics_experimental.unnest_series((
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM timescale_analytics_experimental.unnest_series((
-    SELECT timescale_analytics_experimental.lttb(time, val, 8)
+FROM toolkit_experimental.unnest_series((
+    SELECT toolkit_experimental.lttb(time, val, 8)
     FROM sample_data))
 ```
 ```output
@@ -157,7 +157,7 @@ FROM timescale_analytics_experimental.unnest_series((
 ---
 ## **lttb** <a id="lttb"></a>
 ```SQL,ignore
-timescale_analytics_experimental.lttb(
+toolkit_experimental.lttb(
     time TIMESTAMPTZ,
     value DOUBLE PRECISION,
     resolution INTEGER
@@ -165,7 +165,7 @@ timescale_analytics_experimental.lttb(
 ```
 
 This will construct and return a sorted timeseries with at most `resolution`
-points. `timescale_analytics_experimental.unnest_series(...)` can be used to
+points. `toolkit_experimental.unnest_series(...)` can be used to
 extract the `(time, value)` pairs from this series
 
 ### Required Arguments <a id="lttb-required-arguments"></a>
@@ -180,8 +180,8 @@ extract the `(time, value)` pairs from this series
 
 ```SQL
 SELECT time, value
-FROM timescale_analytics_experimental.unnest_series((
-    SELECT timescale_analytics_experimental.lttb(time, val, 4)
+FROM toolkit_experimental.unnest_series((
+    SELECT toolkit_experimental.lttb(time, val, 4)
     FROM sample_data))
 ```
 ```output

--- a/docs/tdigest.md
+++ b/docs/tdigest.md
@@ -8,7 +8,7 @@
 
 ## Description <a id="tdigest-description"></a>
 
-Timescale analytics provides an implementation of the [t-digest data structure](https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf) for quantile approximations.  A t-digest is a space efficient aggregation which provides increased resolution at the edges of the distribution.  This allows for more accurate estimates of extreme quantiles than traditional methods.
+TimescaleDB Toolkit provides an implementation of the [t-digest data structure](https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf) for quantile approximations.  A t-digest is a space efficient aggregation which provides increased resolution at the edges of the distribution.  This allows for more accurate estimates of extreme quantiles than traditional methods.
 
 ## Details <a id="tdigest-details"></a>
 
@@ -123,7 +123,7 @@ which oscilates between 900 and 1100 over the period of a day.
 ```SQL ,non-transactional
 INSERT INTO test
     SELECT time, value
-    FROM timescale_analytics_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, rng_seed => 543643);
+    FROM toolkit_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, rng_seed => 543643);
 ```
 ```
 INSERT 0 4032

--- a/docs/time_weighted_average.md
+++ b/docs/time_weighted_average.md
@@ -11,7 +11,7 @@
 
 Time weighted averages are commonly used in cases where a time series is not evenly sampled, so a traditional average will give misleading results. Consider a voltage sensor that sends readings once every 5 minutes or whenever the value changes by more than 1 V from the previous reading. If the results are generally stable, but with some quick moving transients, a simple average over all of the points will tend to over-weight the transients instead of the stable readings. A time weighted average weights each value by the duration over which it occured based on the points around it and produces correct results for unevenly spaced series.
 
-Timescale Analytics' time weighted average is implemented as an aggregate which weights each value either using a last observation carried forward (LOCF) approach or a linear interpolation approach ([see interpolation methods](#time-weight-methods)). While the aggregate is not parallelizable, it is supported with [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
+TimescaleDB Toolkit's time weighted average is implemented as an aggregate which weights each value either using a last observation carried forward (LOCF) approach or a linear interpolation approach ([see interpolation methods](#time-weight-methods)). While the aggregate is not parallelizable, it is supported with [continuous aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
 Additionally, [see the notes on parallelism and ordering](#time-weight-ordering) for a deeper dive into considerations for use with parallelism and some discussion of the internal data structures.
 

--- a/docs/two-step_aggregation.md
+++ b/docs/two-step_aggregation.md
@@ -9,23 +9,23 @@ SELECT average(time_weight('LOCF', value)) as time_weighted_average FROM foo;
 SELECT approx_percentile(0.5, percentile_agg(value)) as median FROM bar;
 ```
 
-In each case there is an inner aggregate function (`time_weight` / `percentile_agg`) and an outer call to an accessor function (`average` / `approx_percentile`). We use this calling convention in multiple places throughout the Timescale Analytics project. 
+In each case there is an inner aggregate function (`time_weight` / `percentile_agg`) and an outer call to an accessor function (`average` / `approx_percentile`). We use this calling convention in multiple places throughout the TimescaleDB Toolkit project.
 
 The inner aggregate call creates a machine-readable partial form that can be used for multiple purposes. The two-step calling convention is slightly longer than a hypothetical one-step one where we just called `time_weighted_average('LOCF', value)` or `percentile_agg(0.5, val)` directly (these functions don't exist, don't try to use them).
 
-While the one-step calling convention is easier for the simple case, it becomes much more difficult and hard to reason about for slightly more complex use-cases detailed in the next section. We wanted the calling convention to remain consistent and easy to reason about so you can take advantage of the same functions even as you start doing more complicated analyses.  This also to keeps the docs consistent and prevents adding special cases everywhere. 
+While the one-step calling convention is easier for the simple case, it becomes much more difficult and hard to reason about for slightly more complex use-cases detailed in the next section. We wanted the calling convention to remain consistent and easy to reason about so you can take advantage of the same functions even as you start doing more complicated analyses.  This also to keeps the docs consistent and prevents adding special cases everywhere.
 
 ## Why We Use Two-Step Aggregates <a id="two-step-philosophy"></a>
-Interestingly, almost all Postgres aggregates do a version of this [under the hood already](https://www.postgresql.org/docs/current/xaggr.html), where they have an internal state used for aggregation and then a final function that displays the output to the user. 
+Interestingly, almost all Postgres aggregates do a version of this [under the hood already](https://www.postgresql.org/docs/current/xaggr.html), where they have an internal state used for aggregation and then a final function that displays the output to the user.
 
-So why do we make this calling convention explicit? 
+So why do we make this calling convention explicit?
 
-1) It allows different accessor function calls to use the same internal state and not redo work. 
+1) It allows different accessor function calls to use the same internal state and not redo work.
 2) It cleanly distinguishes the parameters that affect the aggregate and those that only affect the accessor.
 3) It makes it explicit how and when aggregates can be re-aggregated or "stacked" on themselves with logically consistent results. This also helps them better integrate with [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
-4) It allows for better retrospective analysis of downsampled data in [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates). 
+4) It allows for better retrospective analysis of downsampled data in [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates).
 
-That might have been gibberish to some, so let's unpack it a bit. 
+That might have been gibberish to some, so let's unpack it a bit.
 
 ### Accessor functions with additional parameters <a id="philosophy-accessor-funcs"></a>
 The way the optimizer works, if you run an aggregate like:
@@ -35,33 +35,33 @@ SELECT avg(val), sum(val), count(val) FROM foo;
 The internal state of the `avg` is actually the `sum` and the `count` and it just returns `sum / count` in the final step of the aggregate. The optimizer knows, when these functions are used, that it doesn't need to run separate aggregates for each, it can use the same internal function and extract the results it needs. This is great! It can save a lot of work. The problem comes when we do something like `percentile_agg` where we have multiple `approx_percentiles` ie:
 
 ```SQL , ignore
-SELECT 
-    approx_percentile(0.1, percentile_agg(val)) as p10, 
-    approx_percentile(0.5, percentile_agg(val)) as p50, 
-    approx_percentile(0.9, percentile_agg(val)) as p90 
+SELECT
+    approx_percentile(0.1, percentile_agg(val)) as p10,
+    approx_percentile(0.5, percentile_agg(val)) as p50,
+    approx_percentile(0.9, percentile_agg(val)) as p90
 FROM foo;
 ```
 Because the aggregate step is the same for all three of the calls, the optimizer can combine all the calls, or I can do so explicitly:
 
 ```SQL , ignore
 WITH pct as (SELECT percentile_agg(val) as approx FROM foo)
-SELECT 
-    approx_percentile(0.1, approx) as p10, 
-    approx_percentile(0.5, approx) as p50, 
-    approx_percentile(0.9, approx) as p90 
+SELECT
+    approx_percentile(0.1, approx) as p10,
+    approx_percentile(0.5, approx) as p50,
+    approx_percentile(0.9, approx) as p90
 FROM pct;
 ```
 But the work done in each case will be the same.
 
 If we were to use the one-step calling convention, the extra input of the percentile we're trying to extract would comletely confuse the optimizer, and it would have to redo all the calculation inside the aggregate for each of the values you wanted to extract.
 
-So, if it were framed like this: 
+So, if it were framed like this:
 ```SQL , ignore
 -- NB: THIS IS AN EXAMPLE OF AN API WE DECIDED NOT TO USE, IT DOES NOT WORK
-SELECT 
-    approx_percentile(0.1, val) as p10, 
-    approx_percentile(0.5, val) as p50, 
-    approx_percentile(0.9, val) as p90 
+SELECT
+    approx_percentile(0.1, val) as p10,
+    approx_percentile(0.5, val) as p50,
+    approx_percentile(0.9, val) as p90
 FROM foo;
 ```
 the optimizer would be forced to build up the necessary internal state three times rather than just once.
@@ -69,28 +69,28 @@ the optimizer would be forced to build up the necessary internal state three tim
 This is even more apparent when you want to use multiple accessor functions, which may have different numbers or types of inputs:
 
 ```SQL , ignore
-SELECT 
-    approx_percentile(0.1, percentile_agg(val)) as p10, 
-    approx_percentile(0.5, percentile_agg(val)) as p50, 
-    approx_percentile(0.9, percentile_agg(val)) as p90, 
-    error(percentile_agg(val)), 
+SELECT
+    approx_percentile(0.1, percentile_agg(val)) as p10,
+    approx_percentile(0.5, percentile_agg(val)) as p50,
+    approx_percentile(0.9, percentile_agg(val)) as p90,
+    error(percentile_agg(val)),
     approx_percentile_rank(10000, percentile_agg(val)) as percentile_at_threshold
 FROM foo;
 ```
 The optimizer can easily optimize away the redundant `percentile_agg(val)` calls, but would have much more trouble in the one-step approach.
 
 ### Explicit association of parameters with either the aggregation or access step <a id="philosophy-explicit-association"></a>
-This leads us to our second benefit of the two-step approach. A number of our accessor functions (both completed and planned) take inputs that don't affect how we aggregate the underlying data, but do affect how we extract data from the computed aggregate. If we combine everything into one function, it makes it less clear which is which. 
+This leads us to our second benefit of the two-step approach. A number of our accessor functions (both completed and planned) take inputs that don't affect how we aggregate the underlying data, but do affect how we extract data from the computed aggregate. If we combine everything into one function, it makes it less clear which is which.
 
-Now, our `percentile_agg` implementation uses the `uddsketch` algorithm under the hood and has some default values for parameters, namely the number of buckets it stores and the target error, but there are cases where we might want to use the full algorithm with custom parameters like so: 
+Now, our `percentile_agg` implementation uses the `uddsketch` algorithm under the hood and has some default values for parameters, namely the number of buckets it stores and the target error, but there are cases where we might want to use the full algorithm with custom parameters like so:
 ```SQL , ignore
 SELECT
     approx_percentile(0.5, uddsketch(1000, 0.001, val)) as median, -- 1000 buckets, 0.001 relative error target
-    approx_percentile(0.9, uddsketch(1000, 0.001, val)) as p90, 
+    approx_percentile(0.9, uddsketch(1000, 0.001, val)) as p90,
     approx_percentile(0.5, uddsketch(100, 0.01, val)) as less_accurate_median -- modify the terms for the aggregate get a new approximation
 FROM foo;
 ```
-Here we can see which parameters are for the `uddsketch` aggregate (the number of buckets and the target error), and which arguments are for`approx_percentile` (the approx_percentile we want to extract). The optimizer will correctly combine the calls for the first two `uddsketch` calls but not for the third. It is also more clear to the user what is going on, and that I can't set my target error at read time, but rather only at calculation time (this is especially helpful for understanding the behavior of [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates)). 
+Here we can see which parameters are for the `uddsketch` aggregate (the number of buckets and the target error), and which arguments are for`approx_percentile` (the approx_percentile we want to extract). The optimizer will correctly combine the calls for the first two `uddsketch` calls but not for the third. It is also more clear to the user what is going on, and that I can't set my target error at read time, but rather only at calculation time (this is especially helpful for understanding the behavior of [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates)).
 
 Combining all of these into one function, so we can use the one-step approach, can get unwieldy and unclear very quickly (ie imagine something like `approx_percentile_uddsketch(0.5, 1000, 0.001)`).
 <br>
@@ -101,9 +101,9 @@ What I'm calling stackable aggregates are ones like `sum`, `min`, `max` etc. tha
 ```SQL , ignore
 SELECT sum(val) FROM foo;
 -- is equivalent to:
-SELECT sum(sum) 
-FROM 
-    (SELECT id, sum(val) 
+SELECT sum(sum)
+FROM
+    (SELECT id, sum(val)
     FROM foo
     GROUP BY id) s
 ```
@@ -112,16 +112,16 @@ A non-stackable aggregate like `avg` doesn't have this property:
 ```SQL , ignore
 SELECT avg(val) FROM foo;
 -- is NOT equivalent to:
-SELECT avg(avg) 
-FROM 
-    (SELECT id, avg(val) 
+SELECT avg(avg)
+FROM
+    (SELECT id, avg(val)
     FROM foo
     GROUP BY id) s;
 ```
 
 Or to say it more succinctly: the `sum` of a `sum` is the `sum` but the `avg` of an `avg` is not the `avg`. This is the difference between stackable and non-stackable aggregates.
 
-This is not to say that the `avg` of an `avg` is not a useful piece of information, it can be in some cases, but it isn't always what you want and it can be difficult to actually get the true value for non-stackable aggregates, for instance, for `avg` we can take the `count` and `sum` and divide the `sum` by the `count`, but for many aggregates this is not so obvious and for something like `percentile_agg` __LINK__ with a one-step aggregate, the user would simply have to re-implement most of the algorithm in SQL in order to get the result they want. 
+This is not to say that the `avg` of an `avg` is not a useful piece of information, it can be in some cases, but it isn't always what you want and it can be difficult to actually get the true value for non-stackable aggregates, for instance, for `avg` we can take the `count` and `sum` and divide the `sum` by the `count`, but for many aggregates this is not so obvious and for something like `percentile_agg` __LINK__ with a one-step aggregate, the user would simply have to re-implement most of the algorithm in SQL in order to get the result they want.
 
 Two-step aggregates expose the internal, re-aggregateable form to the user so they can much more easily do this work, so we've tried to provide two-step aggregates wherever we can. This is especially useful for working with [continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates), so if I create a continuous aggregate like so:
 
@@ -138,7 +138,7 @@ GROUP BY id, time_bucket('15 min'::interval, ts);
 
 And I want to do a second level of aggregation, say over a day, I can do it over the resulting aggregate with the `percentile_agg` function:
 ```SQL , ignore
-SELECT id, time_bucket('1 day'::interval, bucket) as bucket, 
+SELECT id, time_bucket('1 day'::interval, bucket) as bucket,
     sum(sum),
     approx_percentile(percentile_agg(percentile_agg), 0.5) as median
 FROM foo_15
@@ -149,4 +149,4 @@ GROUP BY id, time_bucket('1 day'::interval, bucket)
 ##### NB: There are some two-step aggregates like `tdigest` __ADD LINK? and expose and other bits...__ when we document that function where two-step aggregation can lead to more error or different results, because the algorithm is not deterministic in its re-aggregation, but we will note that clearly in the documentation when that happens, it is unusual.
 
 ### Retrospective analysis over downsampled data <a id="philosophy-retro"></a>
-[Continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates) (or separate aggregation tables powered by a cron job or [user-defined action]( __LINK__ ) ) aren't just used for speeding up queries, they're also used for [data retention]( __LINK__ ). But this can mean that they are very difficult to modify as your data ages. Unfortunately this is also when you are learning more things about the analysis you want to do on your data. By keeping them in their raw aggregate form, the user has the flexibility to apply different accessors to do retrospective analysis. With a one-step aggregate the user needs to determine, say, which percentiles are important when we create the continous aggregate, with a two-step aggregate the user can simply determine they're going to want an approximate percentile, and then determine when doing the analysis whether they want the median, the 90th, 95th or 1st percentile. No need to modify the aggregate or try to re-calculate from data that may no longer exist in the system. 
+[Continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates) (or separate aggregation tables powered by a cron job or [user-defined action]( __LINK__ ) ) aren't just used for speeding up queries, they're also used for [data retention]( __LINK__ ). But this can mean that they are very difficult to modify as your data ages. Unfortunately this is also when you are learning more things about the analysis you want to do on your data. By keeping them in their raw aggregate form, the user has the flexibility to apply different accessors to do retrospective analysis. With a one-step aggregate the user needs to determine, say, which percentiles are important when we create the continous aggregate, with a two-step aggregate the user can simply determine they're going to want an approximate percentile, and then determine when doing the analysis whether they want the median, the 90th, 95th or 1st percentile. No need to modify the aggregate or try to re-calculate from data that may no longer exist in the system.

--- a/docs/uddsketch.md
+++ b/docs/uddsketch.md
@@ -138,7 +138,7 @@ Next we'll use one of our utility functions, `generate_periodic_normal_series`, 
 ```SQL ,non-transactional
 INSERT INTO test
     SELECT time, value
-    FROM timescale_analytics_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, rng_seed => 12345678);
+    FROM toolkit_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, rng_seed => 12345678);
 ```
 ```
 INSERT 0 4032

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "timescale_analytics"
+name = "timescaledb_toolkit"
 version = "0.3.0"
 edition = "2018"
 

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -10,3 +10,6 @@ asap.generated.sql
 counter_agg.generated.sql
 utilities.generated.sql
 stats_agg.generated.sql
+schema_test.generated.sql
+serialization_collations.generated.sql
+serialization_types.generated.sql

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -30,8 +30,8 @@ static EXPERIMENTAL_ENABLED: GucSetting<bool> = GucSetting::new(false);
 #[pg_guard]
 pub extern "C" fn _PG_init() {
     GucRegistry::define_bool_guc(
-        "timescale_analytics_acknowledge_auto_drop",
-        "enable creation of auto-dropping objects using experimental timescale_analytics_features",
+        "timescaledb_toolkit_acknowledge_auto_drop",
+        "enable creation of auto-dropping objects using experimental timescaledb_toolkit_features",
         "experimental features are very unstable, and objects \
             depending on them will be automatically deleted on extension update",
         &EXPERIMENTAL_ENABLED,

--- a/extension/src/range.rs
+++ b/extension/src/range.rs
@@ -7,12 +7,12 @@ use counter_agg::range::I64Range;
 #[allow(non_camel_case_types)]
 pub type tstzrange = *mut pg_sys::varlena;
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
+// hack to allow us to qualify names with "toolkit_experimental"
 // so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
+mod toolkit_experimental {
     pub(crate) use super::*;
     extension_sql!(r#"
-        CREATE SCHEMA IF NOT EXISTS timescale_analytics_experimental;
+        CREATE SCHEMA IF NOT EXISTS toolkit_experimental;
     "#);
 }
 
@@ -36,7 +36,7 @@ pub unsafe fn get_range(range: tstzrange) -> Option<I64Range> {
         if !lbound_inclusive(flags) {
             left += 1;
         }
-        range.left = Some(left);  
+        range.left = Some(left);
     }
     if range_has_rbound(flags){
         let bytes = range_bytes[..8].try_into().unwrap();
@@ -44,7 +44,7 @@ pub unsafe fn get_range(range: tstzrange) -> Option<I64Range> {
         if rbound_inclusive(flags) {
             right += 1;
         }
-        range.right = Some(right);  
+        range.right = Some(right);
     }
     Some(range)
 
@@ -64,8 +64,8 @@ const RANGE_LB_INC: u8 = 0x02;
 const RANGE_UB_INC: u8 = 0x04;
 const RANGE_LB_INF: u8 = 0x08;
 const RANGE_UB_INF: u8 = 0x10;
-const RANGE_LB_NULL: u8 = 0x20; // should never be used, but why not. 
-const RANGE_UB_NULL: u8 = 0x40; // should never be used, but why not. 
+const RANGE_LB_NULL: u8 = 0x20; // should never be used, but why not.
+const RANGE_UB_NULL: u8 = 0x40; // should never be used, but why not.
 
 fn range_has_lbound(flags: u8) -> bool {
     flags & (RANGE_EMPTY | RANGE_LB_NULL | RANGE_LB_INF) == 0
@@ -156,9 +156,9 @@ impl I64RangeWrapper {
     }
 }
 
-// this introduces a timescaledb dependency, but only kind of, 
+// this introduces a timescaledb dependency, but only kind of,
 extension_sql!(r#"
-CREATE OR REPLACE FUNCTION timescale_analytics_experimental.time_bucket_range( bucket_width interval, ts timestamptz) 
+CREATE OR REPLACE FUNCTION toolkit_experimental.time_bucket_range( bucket_width interval, ts timestamptz)
 RETURNS tstzrange as $$
 SELECT tstzrange(time_bucket(bucket_width, ts), time_bucket(bucket_width, ts + bucket_width), '[)');
 $$

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -5,14 +5,14 @@ mod tests {
 
     use pgx::*;
 
-    #[pg_extern(schema="timescale_analytics_experimental")]
+    #[pg_extern(schema="toolkit_experimental")]
     fn expected_failure() -> i32 { 1 }
 
-    #[pg_test(error = "features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.")]
+    #[pg_test(error = "features in toolkit_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA toolkit_experimental CASCADE), which on Forge can happen at any time.")]
     fn should_fail_blocks_view() {
         Spi::execute(|client| {
             let _ = client.select(
-                "CREATE VIEW failed AS SELECT timescale_analytics_experimental.expected_failure();",
+                "CREATE VIEW failed AS SELECT toolkit_experimental.expected_failure();",
                None,
                 None);
         })
@@ -27,7 +27,7 @@ mod tests {
                 .select(
                     "SELECT pg_catalog.pg_describe_object(classid, objid, 0) \
                     FROM pg_catalog.pg_extension e, pg_catalog.pg_depend d \
-                    WHERE e.extname='timescale_analytics' \
+                    WHERE e.extname='timescaledb_toolkit' \
                     AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass \
                     AND d.refobjid = e.oid \
                     AND deptype = 'e'
@@ -42,7 +42,7 @@ mod tests {
                     }
 
                     if val.starts_with("schema")
-                        && val.strip_prefix("schema ") == Some("timescale_analytics_experimental") {
+                        && val.strip_prefix("schema ") == Some("toolkit_experimental") {
                         return None
                     }
 
@@ -51,13 +51,13 @@ mod tests {
                         return None
                     }
 
-                    let type_prefix = "type timescale_analytics_experimental.";
+                    let type_prefix = "type toolkit_experimental.";
                     if val.starts_with(type_prefix)
                         && val.strip_prefix(type_prefix).is_some() {
                             return None
                     }
 
-                    let function_prefix = "function timescale_analytics_experimental.";
+                    let function_prefix = "function toolkit_experimental.";
                     if val.starts_with(function_prefix)
                         && val.strip_prefix(function_prefix).is_some() {
                             return None
@@ -90,7 +90,7 @@ mod tests {
         "event trigger disallow_experimental_dependencies_on_views",
         "function disallow_experimental_dependencies()",
         "function disallow_experimental_view_dependencies()",
-        "function timescale_analytics_probe()",
+        "function timescaledb_toolkit_probe()",
         "function approx_percentile(double precision,uddsketch)",
         "function approx_percentile_rank(double precision,uddsketch)",
         "function error(uddsketch)",

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -48,9 +48,9 @@ json_inout_funcs!(StatsSummary1D);
 json_inout_funcs!(StatsSummary2D);
 
 
-// hack to allow us to qualify names with "timescale_analytics_experimental"
+// hack to allow us to qualify names with "toolkit_experimental"
 // so that pgx generates the correct SQL
-mod timescale_analytics_experimental {
+mod toolkit_experimental {
     pub(crate) use super::*;
 
     varlena_type!(StatsSummary1D);
@@ -106,7 +106,7 @@ impl<'input> StatsSummary2D<'input> {
 
 
 
-#[pg_extern(schema = "timescale_analytics_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict)]
 pub fn stats1d_trans_serialize<'s>(
     state: Internal<StatsSummary1D<'s>>,
 ) -> bytea {
@@ -114,7 +114,7 @@ pub fn stats1d_trans_serialize<'s>(
     crate::do_serialize!(ser)
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict)]
 pub fn stats1d_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -123,7 +123,7 @@ pub fn stats1d_trans_deserialize(
     de.into()
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict)]
 pub fn stats2d_trans_serialize<'s>(
     state: Internal<StatsSummary2D<'s>>,
 ) -> bytea {
@@ -131,7 +131,7 @@ pub fn stats2d_trans_serialize<'s>(
     crate::do_serialize!(ser)
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict)]
 pub fn stats2d_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -140,7 +140,7 @@ pub fn stats2d_trans_deserialize(
     de.into()
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats1d_trans<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     val: Option<f64>,
@@ -157,7 +157,7 @@ pub fn stats1d_trans<'s>(
                     Some(StatsSummary1D::from_internal(s).into())
                 },
                 (Some(mut state), Some(val)) => {
-                    let mut s: InternalStatsSummary1D = state.to_internal(); 
+                    let mut s: InternalStatsSummary1D = state.to_internal();
                     s.accum(val).unwrap();
                     *state = StatsSummary1D::from_internal(s);
                     Some(state)
@@ -168,7 +168,7 @@ pub fn stats1d_trans<'s>(
 }
 // Note that in general, for all stats2d cases, if either the y or x value is missing, we disregard the entire point as the n is shared between them
 // if the user wants us to treat nulls as a particular value (ie zero), they can use COALESCE to do so
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats2d_trans<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     y: Option<f64>,
@@ -191,7 +191,7 @@ pub fn stats2d_trans<'s>(
                     Some(StatsSummary2D::from_internal(s).into())
                 },
                 (Some(mut state), Some(val)) => {
-                    let mut s: InternalStatsSummary2D = state.to_internal(); 
+                    let mut s: InternalStatsSummary2D = state.to_internal();
                     s.accum(val).unwrap();
                     *state = StatsSummary2D::from_internal(s);
                     Some(state)
@@ -202,7 +202,7 @@ pub fn stats2d_trans<'s>(
 }
 
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats1d_inv_trans<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     val: Option<f64>,
@@ -214,7 +214,7 @@ pub fn stats1d_inv_trans<'s>(
                 (None, _) => panic!("Inverse function should never be called with NULL state"),
                 (Some(state), None) => Some(state),
                 (Some(state), Some(val)) => {
-                    let s: InternalStatsSummary1D = state.to_internal(); 
+                    let s: InternalStatsSummary1D = state.to_internal();
                     let s = s.remove(val);
                     match s {
                         None => None,
@@ -226,7 +226,7 @@ pub fn stats1d_inv_trans<'s>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats2d_inv_trans<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     y: Option<f64>,
@@ -244,7 +244,7 @@ pub fn stats2d_inv_trans<'s>(
                 (None, _) => panic!("Inverse function should never be called with NULL state"),
                 (Some(state), None) => Some(state),
                 (Some(state), Some(val)) => {
-                    let s: InternalStatsSummary2D = state.to_internal(); 
+                    let s: InternalStatsSummary2D = state.to_internal();
                     let s = s.remove(val);
                     match s {
                         None => None,
@@ -257,10 +257,10 @@ pub fn stats2d_inv_trans<'s>(
 }
 
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats1d_summary_trans<'s, 'v>(
     state: Option<Internal<StatsSummary1D<'s>>>,
-    value: Option<timescale_analytics_experimental::StatsSummary1D<'v>>,
+    value: Option<toolkit_experimental::StatsSummary1D<'v>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal<StatsSummary1D<'s>>> {
     unsafe {
@@ -282,10 +282,10 @@ pub fn stats1d_summary_trans<'s, 'v>(
 
 
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats2d_summary_trans<'s, 'v>(
     state: Option<Internal<StatsSummary2D<'s>>>,
-    value: Option<timescale_analytics_experimental::StatsSummary2D<'v>>,
+    value: Option<toolkit_experimental::StatsSummary2D<'v>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal<StatsSummary2D<'s>>> {
     unsafe {
@@ -305,10 +305,10 @@ pub fn stats2d_summary_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats1d_summary_inv_trans<'s, 'v>(
     state: Option<Internal<StatsSummary1D<'s>>>,
-    value: Option<timescale_analytics_experimental::StatsSummary1D<'v>>,
+    value: Option<toolkit_experimental::StatsSummary1D<'v>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal<StatsSummary1D<'s>>> {
     unsafe {
@@ -330,10 +330,10 @@ pub fn stats1d_summary_inv_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats2d_summary_inv_trans<'s, 'v>(
     state: Option<Internal<StatsSummary2D<'s>>>,
-    value: Option<timescale_analytics_experimental::StatsSummary2D<'v>>,
+    value: Option<toolkit_experimental::StatsSummary2D<'v>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal<StatsSummary2D<'s>>> {
     unsafe {
@@ -355,7 +355,7 @@ pub fn stats2d_summary_inv_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats1d_combine<'s, 'v>(
     state1: Option<Internal<StatsSummary1D<'s>>>,
     state2: Option<Internal<StatsSummary1D<'v>>>,
@@ -374,7 +374,7 @@ pub fn stats1d_combine<'s, 'v>(
                     Some(s.into())
                 },
                 (Some(state1), Some(state2)) => {
-                    let s1 = state1.to_internal(); 
+                    let s1 = state1.to_internal();
                     let s2 = state2.to_internal();
                     let s1 = s1.combine(s2).unwrap();
                     Some(StatsSummary1D::from_internal(s1).into())
@@ -384,7 +384,7 @@ pub fn stats1d_combine<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn stats2d_combine<'s, 'v>(
     state1: Option<Internal<StatsSummary2D<'s>>>,
     state2: Option<Internal<StatsSummary2D<'v>>>,
@@ -403,7 +403,7 @@ pub fn stats2d_combine<'s, 'v>(
                     Some(s.into())
                 },
                 (Some(state1), Some(state2)) => {
-                    let s1 = state1.to_internal(); 
+                    let s1 = state1.to_internal();
                     let s2 = state2.to_internal();
                     let s1 = s1.combine(s2).unwrap();
                     Some(StatsSummary2D::from_internal(s1).into())
@@ -413,11 +413,11 @@ pub fn stats2d_combine<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 fn stats1d_final<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<timescale_analytics_experimental::StatsSummary1D<'s>> {
+) -> Option<toolkit_experimental::StatsSummary1D<'s>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             match state {
@@ -428,11 +428,11 @@ fn stats1d_final<'s>(
     }
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 fn stats2d_final<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<timescale_analytics_experimental::StatsSummary2D<'s>> {
+) -> Option<toolkit_experimental::StatsSummary2D<'s>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             match state {
@@ -446,64 +446,64 @@ fn stats2d_final<'s>(
 
 
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.stats_agg( value DOUBLE PRECISION )
+CREATE AGGREGATE toolkit_experimental.stats_agg( value DOUBLE PRECISION )
 (
-    sfunc = timescale_analytics_experimental.stats1d_trans,
+    sfunc = toolkit_experimental.stats1d_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats1d_final,
-    combinefunc = timescale_analytics_experimental.stats1d_combine,
-    serialfunc = timescale_analytics_experimental.stats1d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats1d_trans_deserialize,
-    msfunc = timescale_analytics_experimental.stats1d_trans,
-    minvfunc = timescale_analytics_experimental.stats1d_inv_trans,
+    finalfunc = toolkit_experimental.stats1d_final,
+    combinefunc = toolkit_experimental.stats1d_combine,
+    serialfunc = toolkit_experimental.stats1d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats1d_trans_deserialize,
+    msfunc = toolkit_experimental.stats1d_trans,
+    minvfunc = toolkit_experimental.stats1d_inv_trans,
     mstype = internal,
-    mfinalfunc = timescale_analytics_experimental.stats1d_final,
+    mfinalfunc = toolkit_experimental.stats1d_final,
     parallel = safe
 );
 "#);
 
 // mostly for testing/debugging, in case we want one without the inverse functions defined.
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.stats_agg_no_inv( value DOUBLE PRECISION )
+CREATE AGGREGATE toolkit_experimental.stats_agg_no_inv( value DOUBLE PRECISION )
 (
-    sfunc = timescale_analytics_experimental.stats1d_trans,
+    sfunc = toolkit_experimental.stats1d_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats1d_final,
-    combinefunc = timescale_analytics_experimental.stats1d_combine,
-    serialfunc = timescale_analytics_experimental.stats1d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats1d_trans_deserialize,
+    finalfunc = toolkit_experimental.stats1d_final,
+    combinefunc = toolkit_experimental.stats1d_combine,
+    serialfunc = toolkit_experimental.stats1d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats1d_trans_deserialize,
     parallel = safe
 );
 "#);
 
 // same things for the 2d case
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.stats_agg( y DOUBLE PRECISION, x DOUBLE PRECISION )
+CREATE AGGREGATE toolkit_experimental.stats_agg( y DOUBLE PRECISION, x DOUBLE PRECISION )
 (
-    sfunc = timescale_analytics_experimental.stats2d_trans,
+    sfunc = toolkit_experimental.stats2d_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats2d_final,
-    combinefunc = timescale_analytics_experimental.stats2d_combine,
-    serialfunc = timescale_analytics_experimental.stats2d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats2d_trans_deserialize,
-    msfunc = timescale_analytics_experimental.stats2d_trans,
-    minvfunc = timescale_analytics_experimental.stats2d_inv_trans,
+    finalfunc = toolkit_experimental.stats2d_final,
+    combinefunc = toolkit_experimental.stats2d_combine,
+    serialfunc = toolkit_experimental.stats2d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats2d_trans_deserialize,
+    msfunc = toolkit_experimental.stats2d_trans,
+    minvfunc = toolkit_experimental.stats2d_inv_trans,
     mstype = internal,
-    mfinalfunc = timescale_analytics_experimental.stats2d_final,
+    mfinalfunc = toolkit_experimental.stats2d_final,
     parallel = safe
 );
 "#);
 
 // mostly for testing/debugging, in case we want one without the inverse functions defined.
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.stats_agg_no_inv( y DOUBLE PRECISION, x DOUBLE PRECISION )
+CREATE AGGREGATE toolkit_experimental.stats_agg_no_inv( y DOUBLE PRECISION, x DOUBLE PRECISION )
 (
-    sfunc = timescale_analytics_experimental.stats2d_trans,
+    sfunc = toolkit_experimental.stats2d_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats2d_final,
-    combinefunc = timescale_analytics_experimental.stats2d_combine,
-    serialfunc = timescale_analytics_experimental.stats2d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats2d_trans_deserialize,
+    finalfunc = toolkit_experimental.stats2d_final,
+    combinefunc = toolkit_experimental.stats2d_combine,
+    serialfunc = toolkit_experimental.stats2d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats2d_trans_deserialize,
     parallel = safe
 );
 "#);
@@ -512,32 +512,32 @@ CREATE AGGREGATE timescale_analytics_experimental.stats_agg_no_inv( y DOUBLE PRE
 // you can use it in your window functions (useful for our own perf testing as well)
 
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.rollup(ss timescale_analytics_experimental.statssummary1d)
+CREATE AGGREGATE toolkit_experimental.rollup(ss toolkit_experimental.statssummary1d)
 (
-    sfunc = timescale_analytics_experimental.stats1d_summary_trans,
+    sfunc = toolkit_experimental.stats1d_summary_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats1d_final,
-    combinefunc = timescale_analytics_experimental.stats1d_combine,
-    serialfunc = timescale_analytics_experimental.stats1d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats1d_trans_deserialize,
+    finalfunc = toolkit_experimental.stats1d_final,
+    combinefunc = toolkit_experimental.stats1d_combine,
+    serialfunc = toolkit_experimental.stats1d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats1d_trans_deserialize,
     parallel = safe
 );
 "#);
 
 //  For UI, we decided to have slightly differently named functions for the windowed context and not, so that it reads better, as well as using the inverse function only in the window context
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.rolling(ss timescale_analytics_experimental.statssummary1d)
+CREATE AGGREGATE toolkit_experimental.rolling(ss toolkit_experimental.statssummary1d)
 (
-    sfunc = timescale_analytics_experimental.stats1d_summary_trans,
+    sfunc = toolkit_experimental.stats1d_summary_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats1d_final,
-    combinefunc = timescale_analytics_experimental.stats1d_combine,
-    serialfunc = timescale_analytics_experimental.stats1d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats1d_trans_deserialize,
-    msfunc = timescale_analytics_experimental.stats1d_summary_trans,
-    minvfunc = timescale_analytics_experimental.stats1d_summary_inv_trans,
+    finalfunc = toolkit_experimental.stats1d_final,
+    combinefunc = toolkit_experimental.stats1d_combine,
+    serialfunc = toolkit_experimental.stats1d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats1d_trans_deserialize,
+    msfunc = toolkit_experimental.stats1d_summary_trans,
+    minvfunc = toolkit_experimental.stats1d_summary_inv_trans,
     mstype = internal,
-    mfinalfunc = timescale_analytics_experimental.stats1d_final,
+    mfinalfunc = toolkit_experimental.stats1d_final,
     parallel = safe
 );
 "#);
@@ -546,57 +546,57 @@ CREATE AGGREGATE timescale_analytics_experimental.rolling(ss timescale_analytics
 // Same as for the 1D case, but for the 2D
 
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.rollup(ss timescale_analytics_experimental.statssummary2d)
+CREATE AGGREGATE toolkit_experimental.rollup(ss toolkit_experimental.statssummary2d)
 (
-    sfunc = timescale_analytics_experimental.stats2d_summary_trans,
+    sfunc = toolkit_experimental.stats2d_summary_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats2d_final,
-    combinefunc = timescale_analytics_experimental.stats2d_combine,
-    serialfunc = timescale_analytics_experimental.stats2d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats2d_trans_deserialize,
+    finalfunc = toolkit_experimental.stats2d_final,
+    combinefunc = toolkit_experimental.stats2d_combine,
+    serialfunc = toolkit_experimental.stats2d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats2d_trans_deserialize,
     parallel = safe
 );
 "#);
 
 //  For UI, we decided to have slightly differently named functions for the windowed context and not, so that it reads better, as well as using the inverse function only in the window context
 extension_sql!(r#"
-CREATE AGGREGATE timescale_analytics_experimental.rolling(ss timescale_analytics_experimental.statssummary2d)
+CREATE AGGREGATE toolkit_experimental.rolling(ss toolkit_experimental.statssummary2d)
 (
-    sfunc = timescale_analytics_experimental.stats2d_summary_trans,
+    sfunc = toolkit_experimental.stats2d_summary_trans,
     stype = internal,
-    finalfunc = timescale_analytics_experimental.stats2d_final,
-    combinefunc = timescale_analytics_experimental.stats2d_combine,
-    serialfunc = timescale_analytics_experimental.stats2d_trans_serialize,
-    deserialfunc = timescale_analytics_experimental.stats2d_trans_deserialize,
-    msfunc = timescale_analytics_experimental.stats2d_summary_trans,
-    minvfunc = timescale_analytics_experimental.stats2d_summary_inv_trans,
+    finalfunc = toolkit_experimental.stats2d_final,
+    combinefunc = toolkit_experimental.stats2d_combine,
+    serialfunc = toolkit_experimental.stats2d_trans_serialize,
+    deserialfunc = toolkit_experimental.stats2d_trans_deserialize,
+    msfunc = toolkit_experimental.stats2d_summary_trans,
+    minvfunc = toolkit_experimental.stats2d_summary_inv_trans,
     mstype = internal,
-    mfinalfunc = timescale_analytics_experimental.stats2d_final,
+    mfinalfunc = toolkit_experimental.stats2d_final,
     parallel = safe
 );
 "#);
 
 
 
-#[pg_extern(name="average", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="average", schema = "toolkit_experimental", strict, immutable)]
 fn stats1d_average(
-    summary: timescale_analytics_experimental::StatsSummary1D,
+    summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().avg()
 }
 
-#[pg_extern(name="sum", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="sum", schema = "toolkit_experimental", strict, immutable)]
 fn stats1d_sum(
-    summary: timescale_analytics_experimental::StatsSummary1D,
+    summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().sum()
 }
 
-#[pg_extern(name="stddev", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="stddev", schema = "toolkit_experimental", immutable)]
 fn stats1d_stddev(
-    summary: Option<timescale_analytics_experimental::StatsSummary1D>,
+    summary: Option<toolkit_experimental::StatsSummary1D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -607,9 +607,9 @@ fn stats1d_stddev(
     }
 }
 
-#[pg_extern(name="variance", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="variance", schema = "toolkit_experimental", immutable)]
 fn stats1d_variance(
-    summary: Option<timescale_analytics_experimental::StatsSummary1D>,
+    summary: Option<toolkit_experimental::StatsSummary1D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -620,49 +620,49 @@ fn stats1d_variance(
     }
 }
 
-#[pg_extern(name="num_vals", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable)]
 fn stats1d_num_vals(
-    summary: timescale_analytics_experimental::StatsSummary1D,
+    summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> i64 {
     summary.to_internal().count()
 }
 
-#[pg_extern(name="average_x", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="average_x", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_average_x(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     Some(summary.to_internal().avg()?.x)
 }
 
-#[pg_extern(name="average_y", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="average_y", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_average_y(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     Some(summary.to_internal().avg()?.y)
 }
 
-#[pg_extern(name="sum_x", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="sum_x", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_sum_x(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     Some(summary.to_internal().sum()?.x)
 }
 
-#[pg_extern(name="sum_y", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="sum_y", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_sum_y(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     Some(summary.to_internal().sum()?.y)
 }
 
-#[pg_extern(name="stddev_x", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="stddev_x", schema = "toolkit_experimental", immutable)]
 fn stats2d_stddev_x(
-    summary: Option<timescale_analytics_experimental::StatsSummary2D>,
+    summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -673,9 +673,9 @@ fn stats2d_stddev_x(
     }
 }
 
-#[pg_extern(name="stddev_y", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="stddev_y", schema = "toolkit_experimental", immutable)]
 fn stats2d_stddev_y(
-    summary: Option<timescale_analytics_experimental::StatsSummary2D>,
+    summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -686,9 +686,9 @@ fn stats2d_stddev_y(
     }
 }
 
-#[pg_extern(name="variance_x", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="variance_x", schema = "toolkit_experimental", immutable)]
 fn stats2d_variance_x(
-    summary: Option<timescale_analytics_experimental::StatsSummary2D>,
+    summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -699,9 +699,9 @@ fn stats2d_variance_x(
     }
 }
 
-#[pg_extern(name="variance_y", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="variance_y", schema = "toolkit_experimental", immutable)]
 fn stats2d_variance_y(
-    summary: Option<timescale_analytics_experimental::StatsSummary2D>,
+    summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -712,57 +712,57 @@ fn stats2d_variance_y(
     }
 }
 
-#[pg_extern(name="num_vals", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_num_vals(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> i64 {
     summary.to_internal().count()
 }
 
-#[pg_extern(name="slope", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="slope", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_slope(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().slope()
 }
 
-#[pg_extern(name="corr", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="corr", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_corr(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().corr()
 }
 
-#[pg_extern(name="intercept", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="intercept", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_intercept(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().intercept()
 }
 
-#[pg_extern(name="x_intercept", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="x_intercept", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_x_intercept(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().x_intercept()
 }
 
-#[pg_extern(name="determination_coeff", schema = "timescale_analytics_experimental", strict, immutable)]
+#[pg_extern(name="determination_coeff", schema = "toolkit_experimental", strict, immutable)]
 fn stats2d_determination_coeff(
-    summary: timescale_analytics_experimental::StatsSummary2D,
+    summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
     summary.to_internal().determination_coeff()
 }
 
-#[pg_extern(name="covariance", schema = "timescale_analytics_experimental", immutable)]
+#[pg_extern(name="covariance", schema = "toolkit_experimental", immutable)]
 fn stats2d_covar(
-    summary: Option<timescale_analytics_experimental::StatsSummary2D>,
+    summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "population"),
     _fcinfo: pg_sys::FunctionCallInfo,
 )-> Option<f64> {
@@ -808,7 +808,7 @@ fn stats2d_covar(
 //         assert_relative_eq!(p1.syy, p2.syy);
 //         assert_relative_eq!(p1.sxy, p2.sxy);
 //     }
-    
+
 
 
 //     // #[pg_test]

--- a/extension/src/triggers.rs
+++ b/extension/src/triggers.rs
@@ -3,7 +3,7 @@ use pgx::*;
 /// nop function that forces the extension binary to be loaded, this ensures
 /// that if a user sees the error message the guc will in fact be active
 #[pg_extern]
-fn timescale_analytics_probe() {
+fn timescaledb_toolkit_probe() {
 
 }
 
@@ -17,7 +17,7 @@ DECLARE
   experimental_schema_id oid;
 BEGIN
 
-  guc_set := current_setting('timescale_analytics_acknowledge_auto_drop', true);
+  guc_set := current_setting('timescaledb_toolkit_acknowledge_auto_drop', true);
   IF guc_set IS NOT NULL AND guc_set = 'on' THEN
     RETURN;
   END IF;
@@ -25,7 +25,7 @@ BEGIN
   SELECT oid schema_oid
   INTO experimental_schema_id
   FROM pg_catalog.pg_namespace
-  WHERE nspname='timescale_analytics_experimental'
+  WHERE nspname='toolkit_experimental'
   LIMIT 1;
 
   IF EXISTS (
@@ -41,9 +41,9 @@ BEGIN
         WHERE NOT obj.in_extension
       ) created ON created.id = depend.objid))
   THEN
-    PERFORM timescale_analytics_probe();
-    RAISE EXCEPTION 'features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.'
-      USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescale_analytics_acknowledge_auto_drop to ''true''.';
+    PERFORM timescaledb_toolkit_probe();
+    RAISE EXCEPTION 'features in toolkit_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA toolkit_experimental CASCADE), which on Forge can happen at any time.'
+      USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescaledb_toolkit_acknowledge_auto_drop to ''true''.';
   END IF;
 END;
 $$;
@@ -57,7 +57,7 @@ DECLARE
   experimental_schema_id oid;
 BEGIN
 
-  guc_set := current_setting('timescale_analytics_acknowledge_auto_drop', true);
+  guc_set := current_setting('timescaledb_toolkit_acknowledge_auto_drop', true);
   IF guc_set IS NOT NULL AND guc_set = 'on' THEN
     RETURN;
   END IF;
@@ -65,7 +65,7 @@ BEGIN
   SELECT oid schema_oid
   INTO experimental_schema_id
   FROM pg_catalog.pg_namespace
-  WHERE nspname='timescale_analytics_experimental'
+  WHERE nspname='toolkit_experimental'
   LIMIT 1;
 
   -- views do not depend directly on objects, instead the rewrite rule depends
@@ -85,9 +85,9 @@ BEGIN
       INNER JOIN pg_catalog.pg_depend depend2 ON depend2.objid = depend.objid)
     )
   THEN
-    PERFORM timescale_analytics_probe();
-    RAISE EXCEPTION 'features in timescale_analytics_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA timescale_analytics_experimental CASCADE), which on Forge can happen at any time.'
-        USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescale_analytics_acknowledge_auto_drop to ''true''.';
+    PERFORM timescaledb_toolkit_probe();
+    RAISE EXCEPTION 'features in toolkit_experimental are unstable, and objects depending on them will be deleted on extension update (there will be a DROP SCHEMA toolkit_experimental CASCADE), which on Forge can happen at any time.'
+        USING DETAIL='If you really want to do this, and are willing to accept the possibility that objects so created may be deleted without warning, set timescaledb_toolkit_acknowledge_auto_drop to ''true''.';
   END IF;
 END;
 $$;

--- a/extension/src/utilities.rs
+++ b/extension/src/utilities.rs
@@ -1,7 +1,7 @@
 use pgx::*;
 use pg_sys::{TimestampTz};
 
-#[pg_extern(name="generate_periodic_normal_series", schema = "timescale_analytics_experimental")]
+#[pg_extern(name="generate_periodic_normal_series", schema = "toolkit_experimental")]
 pub fn default_generate_periodic_normal_series(
     series_start: pg_sys::TimestampTz,
     rng_seed: Option<i64>,
@@ -19,14 +19,14 @@ pub fn alternate_generate_periodic_normal_series(
     standard_deviation: f64,
     rng_seed: Option<i64>,
 ) -> impl std::iter::Iterator<Item = (name!(time,TimestampTz),name!(value,f64))> + 'static {
-    generate_periodic_normal_series(series_start, 
+    generate_periodic_normal_series(series_start,
         Some(periods_per_series * points_per_period * seconds_between_points * 1000000),
-        Some(seconds_between_points * 1000000), Some(base_value), 
+        Some(seconds_between_points * 1000000), Some(base_value),
         Some(points_per_period * seconds_between_points * 1000000),Some(periodic_magnitude),
         Some(standard_deviation), rng_seed)
 }
 
-#[pg_extern(schema = "timescale_analytics_experimental")]
+#[pg_extern(schema = "toolkit_experimental")]
 pub fn generate_periodic_normal_series(
     series_start: pg_sys::TimestampTz,
     series_len: Option<i64>, //pg_sys::Interval,
@@ -79,7 +79,7 @@ pub fn generate_periodic_normal_series(
     };
 
     let distribution = rand_distr::Normal::new(0.0, standard_deviation).unwrap();
-    
+
     (0..series_len).step_by(sample_interval as usize).map(move |accum| {
         let time = series_start + accum;
         let base = base_value + f64::sin(accum as f64 / (2.0 * std::f64::consts::PI * period as f64)) * periodic_magnitude;

--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,8 +1,8 @@
-comment = 'timescale_analytics'
+comment = 'timescaledb_toolkit'
 default_version = '1.0'
 relocatable = false
 superuser = false
-module_pathname = '$libdir/timescale_analytics' # only for testing, will be removed for real installs
+module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
 # upgradeable_from = '0.1, 0.2'

--- a/tools/post-install/src/main.rs
+++ b/tools/post-install/src/main.rs
@@ -32,16 +32,16 @@ fn try_main() -> xshell::Result<()> {
 
     let extension_info = get_extension_info(&pg_config)?;
 
-    // remove `module_path = '$libdir/timescale_analytics'`
-    // from timescale_analytics.control.
+    // remove `module_path = '$libdir/timescaledb_toolkit'`
+    // from timescaledb_toolkit.control.
     // Not needed for correctness purposes, but it ensures that if `MODULE_PATH`
     // is left anywhere in the install script, it will fail to install.
     remove_module_path_from_control_file(&extension_info);
 
-    // rename timescale_analytics.so to timescale_analytics-<current version>.so
+    // rename timescaledb_toolkit.so to timescaledb_toolkit-<current version>.so
     add_version_to_binary(&extension_info);
 
-    // replace `MODULE_PATH` with `$libdir/timescale_analytics-<current version>`
+    // replace `MODULE_PATH` with `$libdir/timescaledb_toolkit-<current version>`
     add_version_to_install_script(&extension_info);
 
     generate_update_scripts(&extension_info);
@@ -63,7 +63,7 @@ fn get_extension_info(pg_config: &str) -> xshell::Result<ExtensionInfo> {
     let share_dir = cmd!("{pg_config} --sharedir").read()?;
     let extension_dir = path!(share_dir/"extension");
 
-    let control_file = path!(extension_dir/"timescale_analytics.control");
+    let control_file = path!(extension_dir/"timescaledb_toolkit.control");
 
     let control_contents = fs::read_to_string(&control_file).unwrap_or_else(|e| panic!(
         "cannot read control file {} due to {}",
@@ -119,8 +119,8 @@ fn remove_module_path_from_control_file(
 fn add_version_to_binary(
     ExtensionInfo { current_version, bin_dir, .. } : &ExtensionInfo
 ) {
-    let bin_file = path!(bin_dir/"timescale_analytics.so");
-    let versioned_file = path!(bin_dir/format!("timescale_analytics-{}.so", current_version));
+    let bin_file = path!(bin_dir/"timescaledb_toolkit.so");
+    let versioned_file = path!(bin_dir/format!("timescaledb_toolkit-{}.so", current_version));
     rename_file(bin_file, versioned_file);
 }
 
@@ -128,11 +128,11 @@ fn add_version_to_binary(
 fn add_version_to_install_script(
     ExtensionInfo { current_version, extension_dir, .. } : &ExtensionInfo
 ) {
-    let install_script = path!(extension_dir/format!("timescale_analytics--{}.sql", current_version));
+    let install_script = path!(extension_dir/format!("timescaledb_toolkit--{}.sql", current_version));
 
     let versioned_script = install_script.with_extension("sql.tmp");
 
-    let module_path = format!("$libdir/timescale_analytics-{}", current_version);
+    let module_path = format!("$libdir/timescaledb_toolkit-{}", current_version);
 
     transform_file_to(&install_script, &versioned_script, |line| {
         if line.contains("MODULE_PATHNAME") {
@@ -151,13 +151,13 @@ fn add_version_to_install_script(
 fn generate_update_scripts(
     ExtensionInfo { current_version, upgradeable_from, extension_dir, .. }: &ExtensionInfo
 ) {
-    let extension_path = path!(extension_dir/format!("timescale_analytics--{}.sql", current_version));
+    let extension_path = path!(extension_dir/format!("timescaledb_toolkit--{}.sql", current_version));
 
     for from_version in upgradeable_from {
         let mut extension_file = open_file(&extension_path);
 
         let upgrade_path = path!(extension_dir/format!(
-            "timescale_analytics--{from}--{to}.sql", from=from_version, to=current_version
+            "timescaledb_toolkit--{from}--{to}.sql", from=from_version, to=current_version
         ));
         let mut upgrade_file = create_file(&upgrade_path);
 

--- a/tools/post-install/src/update_script.rs
+++ b/tools/post-install/src/update_script.rs
@@ -24,7 +24,7 @@ pub (crate) fn generate_from_install(
 ) {
     writeln!(
         &mut upgrade_file,
-        "DROP SCHEMA timescale_analytics_experimental CASCADE;\n\
+        "DROP SCHEMA toolkit_experimental CASCADE;\n\
         -- drop the EVENT TRIGGERs; there's no CREATE OR REPLACE for those
         DROP EVENT TRIGGER disallow_experimental_deps CASCADE;\n\
         DROP EVENT TRIGGER disallow_experimental_dependencies_on_views CASCADE;"

--- a/tools/testrunner/src/main.rs
+++ b/tools/testrunner/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
         .expect("could not connect to test DB");
 
     println!("{}", "Creating Extension".bold().green());
-    client.simple_query("CREATE EXTENSION timescale_analytics;"
+    client.simple_query("CREATE EXTENSION timescaledb_toolkit;"
         ).expect("cannot retrieve test names");
 
     println!("{}", "Retrieving Tests".bold().green());


### PR DESCRIPTION
The Timescale Analytics name was always a working title, chosen so we could make progress while choosing a real one. This PR changes the extension to it's final name: TimescaleDB Toolkit. This PR changes all mentions of Timescale Analytics to TimescaleDB Toolkit _except_ for references to this repo's URL https://github.com/timescale/timescale-analytics, those references will be changed after the repository itself is renamed.

With the rename of the extension we're also renaming the experimental schema: it is now `toolkit_experimental`.